### PR TITLE
P3-51(#43) [FEAT]: 트레이딩 - 체결 : 체결 단계에서의 예외처리 및 매칭 모듈로의 롤백 구현

### DIFF
--- a/execution-service/src/main/java/finpago/executionservice/OrderStatus.java
+++ b/execution-service/src/main/java/finpago/executionservice/OrderStatus.java
@@ -1,0 +1,8 @@
+package finpago.executionservice;
+
+public enum OrderStatus {
+    CREATED,    //생성됨
+    PENDING,    // 미체결
+    FINISHED,   // 체결 완료
+    FAILED    // 취소됨
+}

--- a/execution-service/src/main/java/finpago/executionservice/OrderType.java
+++ b/execution-service/src/main/java/finpago/executionservice/OrderType.java
@@ -1,0 +1,6 @@
+package finpago.executionservice;
+
+public enum OrderType {
+    BUY,
+    SELL
+}

--- a/execution-service/src/main/java/finpago/executionservice/execution/messaging/consumer/ExecutionConsumer.java
+++ b/execution-service/src/main/java/finpago/executionservice/execution/messaging/consumer/ExecutionConsumer.java
@@ -22,8 +22,8 @@ public class ExecutionConsumer {
 
     @KafkaListener(topics = "settlement-failure-topic", groupId = "execution-service-group")
     public void handleFailedSettlement(TradeMatchingEvent event) {
-        log.warn("⚠️ 정산 실패 처리: {}", event);
-        executionService.handleSettlementFailure(event); // ✅ 이벤트 전체 전달
+        log.warn("정산 실패 처리: {}", event);
+        executionService.handleSettlementFailure(event);
     }
 
 }

--- a/execution-service/src/main/java/finpago/executionservice/execution/messaging/events/OrderCreateReqEvent.java
+++ b/execution-service/src/main/java/finpago/executionservice/execution/messaging/events/OrderCreateReqEvent.java
@@ -1,0 +1,24 @@
+package finpago.executionservice.execution.messaging.events;
+
+import finpago.executionservice.OrderStatus;
+import finpago.executionservice.OrderType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderCreateReqEvent {
+    private UUID offerNumber;
+    private Long userId;
+    private OrderType offerType;
+    private Long offerQuantity;
+    private Long offerPrice;
+    private String stockTicker;
+    private OrderStatus orderStatus;
+    private LocalDateTime createdAt;
+}

--- a/execution-service/src/main/java/finpago/executionservice/execution/messaging/producer/ExecutionProducer.java
+++ b/execution-service/src/main/java/finpago/executionservice/execution/messaging/producer/ExecutionProducer.java
@@ -1,5 +1,8 @@
 package finpago.executionservice.execution.messaging.producer;
 
+import finpago.executionservice.OrderStatus;
+import finpago.executionservice.OrderType;
+import finpago.executionservice.execution.messaging.events.OrderCreateReqEvent;
 import finpago.executionservice.execution.messaging.events.TradeMatchingEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,11 +14,18 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class ExecutionProducer {
 
-    private final KafkaTemplate<String, TradeMatchingEvent> kafkaTemplate;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
     private static final String TRADE_EXECUTION_TOPIC = "trade-execution-topic";
+    private static final String FAILED_EXECUTION_TOPIC = "failed-execution-topic";
 
     public void sendTradeToSettlement(TradeMatchingEvent tradeEvent) {
         kafkaTemplate.send(TRADE_EXECUTION_TOPIC, tradeEvent);
         log.info("체결된 주문을 Settlement 모듈로 전송: {}", tradeEvent);
     }
+
+    public void sendFailedTradeToMatching(OrderCreateReqEvent failedEvent) {
+        kafkaTemplate.send(FAILED_EXECUTION_TOPIC, failedEvent);
+        log.info("체결 실패 주문을 Matching 모듈로 전송: {}", failedEvent);
+    }
+
 }

--- a/matching-service/src/main/java/finpago/matchingservice/matching/config/KafkaConfig.java
+++ b/matching-service/src/main/java/finpago/matchingservice/matching/config/KafkaConfig.java
@@ -21,7 +21,7 @@ import java.util.Map;
 public class KafkaConfig {
 
     private static final String BOOTSTRAP_SERVERS = "localhost:9092";
-    private static final String GROUP_ID = "matching-service-group";
+    private static final String GROUP_ID = "execution-service-group";
 
     @Bean
     public ProducerFactory<String, OrderCreateReqEvent> producerFactory() {

--- a/matching-service/src/main/java/finpago/matchingservice/matching/config/KafkaRetryConfig.java
+++ b/matching-service/src/main/java/finpago/matchingservice/matching/config/KafkaRetryConfig.java
@@ -15,7 +15,7 @@ import org.springframework.util.backoff.FixedBackOff;
 @Configuration
 public class KafkaRetryConfig {
 
-    private static final String DLT_TOPIC = "matching-dlt-topic"; //DLT 토픽
+    private static final String DLT_TOPIC = "execution-dlt-topic"; //DLT 토픽
     private static final long RETRY_INTERVAL = 1000L; // 재시도 간격 (1초)
     private static final int RETRY_COUNT = 3; // 최대 재시도 횟수
 

--- a/matching-service/src/main/java/finpago/matchingservice/matching/messaging/consumer/MatchingConsumer.java
+++ b/matching-service/src/main/java/finpago/matchingservice/matching/messaging/consumer/MatchingConsumer.java
@@ -13,14 +13,16 @@ import org.springframework.stereotype.Component;
 public class MatchingConsumer {
 
     private final MatchingService matchingService;
+    private static final String ORDER_TOPIC = "order-topic";
+    private static final String FAILED_EXECUTION_TOPIC = "failed-execution-topic";
 
-    @KafkaListener(topics = "order-topic", groupId = "matching-service-group")
+    @KafkaListener(topics = ORDER_TOPIC, groupId = "matching-service-group")
     public void handleNewOrder(OrderCreateReqEvent order) {
         log.info("새 주문 수신: {}", order);
         matchingService.processOrder(order);
     }
 
-    @KafkaListener(topics = "failed-execution-topic", groupId = "matching-service-group")
+    @KafkaListener(topics = FAILED_EXECUTION_TOPIC, groupId = "matching-service-group")
     public void handleFailedTrade(OrderCreateReqEvent failedOrder) {
         log.warn("체결 실패 주문 재매칭: {}", failedOrder);
         matchingService.processOrder(failedOrder); // 실패 주문을 다시 매칭 큐에 삽입


### PR DESCRIPTION
## PR Type
기능 추가

## 해당 PR에 대한 설명
1. Execution 모듈
- processTrade에서 Redis 예수금/보유 주식 조회 & 부족 시 예외처리
- 환율 정보 Redis에서 조회 (없을 경우 기본값 적용)
- 체결 실패 시 Matching 모듈로 롤백 (sendFailedTradeToMatching)

2. Matching 모듈
- handleFailedTrade에서 체결 실패 주문을 다시 매칭 큐에 삽입
- OrderCreateReqEvent 복원 로직을 Service 단에서 처리
- Kafka DLT (failed-execution-topic) 추가하여 체결 실패 복구 지원

3. Kafka Producer/Consumer 개선
- ExecutionProducer: 체결 실패 주문을 Matching 모듈로 재매칭
- MatchingConsumer: 실패 주문을 다시 큐에 삽입하여 매칭 로직 수행