### PR TITLE
P3-74(#70) [ADD]: 주문가능금액, 예수금 분리 및 매도가능 주식, 보유주식 분리

### DIFF
--- a/order-service/src/main/java/finpago/orderservice/order/service/OrderService.java
+++ b/order-service/src/main/java/finpago/orderservice/order/service/OrderService.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -25,17 +26,17 @@ public class OrderService {
     private final OrderProducer orderProducer;
     private final StringRedisTemplate redisTemplate;
 
-    private static final long DEFAULT_BALANCE = 1000000; // 기본 예수금 (1,000,000)
-    private static final long DEFAULT_STOCKS = 100L; // 기본 보유 주식 수량 (100주)
+    private static final long DEFAULT_BALANCE = 1_000_000L; // 기본 예수금
+    private static final long DEFAULT_STOCKS = 100L; // 기본 보유 주식 수량
 
     @Transactional
     public UUID createOrder(Long userId, OrderCreateReqDto orderCreateReqDto) {
         OrderType orderType = OrderType.valueOf(orderCreateReqDto.getOfferType());
 
         if (orderType == OrderType.BUY) {
-            validateBalance(orderCreateReqDto);
+            validateAndDeductAvailableBalance(orderCreateReqDto);
         } else if (orderType == OrderType.SELL) {
-            validateStocks(orderCreateReqDto);
+            validateAndDeductAvailableStocks(orderCreateReqDto);
         }
 
         // 검증 통과 후 주문 저장 & Kafka 메시지 발행
@@ -47,8 +48,6 @@ public class OrderService {
                 .userId(userId)
                 .stockTicker(orderCreateReqDto.getStockTicker())
                 .build();
-
-        System.out.println(order);
 
         orderRepository.save(order);
 
@@ -69,40 +68,74 @@ public class OrderService {
     }
 
     /**
-     * BUY 주문 시 예수금 검증
+     * 매수 주문 시 사용 가능 예수금 검증 후 차감
      */
-    private void validateBalance(OrderCreateReqDto orderCreateReqDto) {
-        Long buyerAvailableBalance = getCachedBalance(orderCreateReqDto.getUserId());
+    private void validateAndDeductAvailableBalance(OrderCreateReqDto orderCreateReqDto) {
+        Long availableBalance = getCachedAvailableBalance(orderCreateReqDto.getUserId());
+        Long requiredAmount = orderCreateReqDto.getOfferPrice() * orderCreateReqDto.getOfferQuantity();
 
-        if (buyerAvailableBalance < orderCreateReqDto.getOfferPrice()) {
+        if (availableBalance < requiredAmount) {
             log.error("예수금 부족 - User ID: {}, 필요 금액: {}, 보유 금액: {}",
-                    orderCreateReqDto.getUserId(), orderCreateReqDto.getOfferPrice(), buyerAvailableBalance);
+                    orderCreateReqDto.getUserId(), requiredAmount, availableBalance);
             throw new InsufficientBalanceException("예수금이 부족합니다");
         }
+
+        // 사용 가능 예수금 차감
+        updateAvailableBalance(orderCreateReqDto.getUserId(), -requiredAmount);
+        log.info("매수 주문 - 사용 가능 예수금 차감: 사용자 {}, 차감 금액 {}", orderCreateReqDto.getUserId(), requiredAmount);
     }
 
     /**
-     * SELL 주문 시 보유 주식 검증
+     * 매도 주문 시 사용 가능 주식 검증 후 차감
      */
-    private void validateStocks(OrderCreateReqDto orderCreateReqDto) {
-        Long sellerAvailableStocks = getCachedStocks(orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker());
+    private void validateAndDeductAvailableStocks(OrderCreateReqDto orderCreateReqDto) {
+        Long availableStocks = getCachedAvailableStocks(orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker());
 
-        if (sellerAvailableStocks < orderCreateReqDto.getOfferQuantity()) {
+        if (availableStocks < orderCreateReqDto.getOfferQuantity()) {
             log.error("보유 주식 부족 - User ID: {}, 필요 주식: {}, 보유 주식: {}",
-                    orderCreateReqDto.getUserId(), orderCreateReqDto.getOfferQuantity(), sellerAvailableStocks);
-            throw new InsufficientStockException("보유주식이 부족합니다");
+                    orderCreateReqDto.getUserId(), orderCreateReqDto.getOfferQuantity(), availableStocks);
+            throw new InsufficientStockException("보유 주식이 부족합니다");
         }
+
+        // 사용 가능 주식 차감
+        updateAvailableStocks(orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker(), -orderCreateReqDto.getOfferQuantity());
+        log.info("매도 주문 - 사용 가능 주식 차감: 사용자 {}, 종목 {}, 차감 수량 {}",
+                orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker(), orderCreateReqDto.getOfferQuantity());
     }
 
-    private Long getCachedBalance(Long userId) {
-        String balanceKey = "user:" + userId + ":balance";
+    /**
+     * 사용 가능 예수금 조회
+     */
+    private Long getCachedAvailableBalance(Long userId) {
+        String balanceKey = "user:" + userId + ":available_balance";
         String balanceStr = redisTemplate.opsForValue().get(balanceKey);
         return balanceStr != null ? Long.parseLong(balanceStr) : DEFAULT_BALANCE;
     }
 
-    private Long getCachedStocks(Long userId, String stockTicker) {
-        String stockKey = "user:" + userId + ":stocks:" + stockTicker;
+    /**
+     * 사용 가능 주식 조회
+     */
+    private Long getCachedAvailableStocks(Long userId, String stockTicker) {
+        String stockKey = "user:" + userId + ":available_stocks:" + stockTicker;
         String stockStr = redisTemplate.opsForValue().get(stockKey);
         return stockStr != null ? Long.parseLong(stockStr) : DEFAULT_STOCKS;
+    }
+
+    /**
+     * 사용 가능 예수금 업데이트
+     */
+    private void updateAvailableBalance(Long userId, Long amount) {
+        String balanceKey = "user:" + userId + ":available_balance";
+        Long currentBalance = getCachedAvailableBalance(userId);
+        redisTemplate.opsForValue().set(balanceKey, String.valueOf(currentBalance + amount), 5, TimeUnit.MINUTES);
+    }
+
+    /**
+     * 사용 가능 주식 업데이트
+     */
+    private void updateAvailableStocks(Long userId, String stockTicker, Long quantity) {
+        String stockKey = "user:" + userId + ":available_stocks:" + stockTicker;
+        Long currentStocks = getCachedAvailableStocks(userId, stockTicker);
+        redisTemplate.opsForValue().set(stockKey, String.valueOf(currentStocks + quantity), 5, TimeUnit.MINUTES);
     }
 }

--- a/settlement-service/src/main/java/finpago/settlementservice/settlement/service/SettlementService.java
+++ b/settlement-service/src/main/java/finpago/settlementservice/settlement/service/SettlementService.java
@@ -1,5 +1,7 @@
 package finpago.settlementservice.settlement.service;
 
+import finpago.common.global.exception.error.InsufficientBalanceException;
+import finpago.common.global.exception.error.InsufficientStockException;
 import finpago.common.global.messaging.TradeMatchingEvent;
 import finpago.settlementservice.settlement.messaging.producer.SettlementProducer;
 import lombok.RequiredArgsConstructor;
@@ -17,8 +19,8 @@ public class SettlementService {
     private final StringRedisTemplate redisTemplate;
     private final SettlementProducer settlementProducer;
 
-    private static final long DEFAULT_BALANCE = 1_000_000L; // 기본 예수금 (1,000,000)
-    private static final long DEFAULT_STOCKS = 1000000; // 기본 보유 주식 수량 (100주)
+    private static final long DEFAULT_BALANCE = 1_000_000L; // 기본 예수금
+    private static final long DEFAULT_STOCKS = 1000000; // 기본 보유 주식 수량
     private static final float DEFAULT_EXCHANGE_RATE = 1.0f; // 기본 환율 (1.0)
 
     @Transactional
@@ -29,16 +31,21 @@ public class SettlementService {
         // Redis에서 환율 조회 (없을 경우 기본값 적용)
         Float exchangeRate = getExchangeRate(event.getStockTicker());
 
-        // 정산 수행
-        updateBalance(event.getBuyerUserId(), -event.getTradePrice() * event.getTradeQuantity());
-        updateStocks(event.getBuyerUserId(), event.getStockTicker(), event.getTradeQuantity());
-        updateStockForFxTracking(event.getBuyerUserId(), event.getStockTicker(), event.getTradeQuantity(), exchangeRate);
+        // 매수자(BUY) 처리
+        updateBalance(event.getBuyerUserId(), -event.getTradePrice() * event.getTradeQuantity()); // 실제 예수금 감소
+        updateAvailableStocks(event.getBuyerUserId(), event.getStockTicker(), event.getTradeQuantity()); // 사용 가능 주식 증가
+        updateHoldings(event.getBuyerUserId(), event.getStockTicker(), event.getTradeQuantity()); // 보유 주식 증가 (배치)
 
-        updateBalance(event.getSellerUserId(), event.getTradePrice() * event.getTradeQuantity());
-        updateStocks(event.getSellerUserId(), event.getStockTicker(), -event.getTradeQuantity());
+        // 매도자(SELL) 처리
+        updateAvailableBalance(event.getSellerUserId(), event.getTradePrice() * event.getTradeQuantity()); // 사용 가능 예수금 증가
+        updateBalance(event.getSellerUserId(), event.getTradePrice() * event.getTradeQuantity()); // 실제 예수금 증가 (배치)
+        updateAvailableStocks(event.getSellerUserId(), event.getStockTicker(), -event.getTradeQuantity()); // 사용 가능 주식 감소
+        updateHoldings(event.getSellerUserId(), event.getStockTicker(), -event.getTradeQuantity()); // 보유 주식 감소 (즉시 반영)
+
+        // 환차손익 저장
+        updateStockForFxTracking(event.getBuyerUserId(), event.getStockTicker(), event.getTradeQuantity(), exchangeRate);
         updateStockForFxTracking(event.getSellerUserId(), event.getStockTicker(), -event.getTradeQuantity(), exchangeRate);
 
-        // 정산 완료 후 메시지 발행
         settlementProducer.sendSettlementSuccess(event);
         log.info("정산 완료: {}", event);
     }
@@ -47,14 +54,14 @@ public class SettlementService {
      * 매수자의 예수금 검증
      */
     private void validateBuyerBalance(TradeMatchingEvent event) {
-        Long buyerAvailableBalance = getCachedBalance(event.getBuyerUserId());
+        Long buyerAvailableBalance = getCachedAvailableBalance(event.getBuyerUserId());
         Long requiredAmount = event.getTradePrice() * event.getTradeQuantity();
 
         if (buyerAvailableBalance < requiredAmount) {
             log.error("예수금 부족 - 매수자 ID: {}, 필요 금액: {}, 보유 금액: {}",
                     event.getBuyerUserId(), requiredAmount, buyerAvailableBalance);
             settlementProducer.sendSettlementFailure(event);
-            throw new IllegalStateException("예수금 부족으로 정산 실패");
+            throw new InsufficientBalanceException("예수금 부족으로 정산 실패");
         }
     }
 
@@ -62,24 +69,30 @@ public class SettlementService {
      * 매도자의 보유 주식 검증
      */
     private void validateSellerStocks(TradeMatchingEvent event) {
-        Long sellerAvailableStocks = getCachedStocks(event.getSellerUserId(), event.getStockTicker());
+        Long sellerAvailableStocks = getCachedAvailableStocks(event.getSellerUserId(), event.getStockTicker());
 
         if (sellerAvailableStocks < event.getTradeQuantity()) {
             log.error("보유 주식 부족 - 매도자 ID: {}, 필요 주식: {}, 보유 주식: {}",
                     event.getSellerUserId(), event.getTradeQuantity(), sellerAvailableStocks);
             settlementProducer.sendSettlementFailure(event);
-            throw new IllegalStateException("보유 주식 부족으로 정산 실패");
+            throw new InsufficientStockException("보유 주식 부족으로 정산 실패");
         }
     }
 
-    private Long getCachedBalance(Long userId) {
-        String balanceKey = "user:" + userId + ":balance";
+    /**
+     * 사용 가능 예수금 조회
+     */
+    private Long getCachedAvailableBalance(Long userId) {
+        String balanceKey = "user:" + userId + ":available_balance";
         String balanceStr = redisTemplate.opsForValue().get(balanceKey);
         return balanceStr != null ? Long.parseLong(balanceStr) : DEFAULT_BALANCE;
     }
 
-    private Long getCachedStocks(Long userId, String stockTicker) {
-        String stockKey = "user:" + userId + ":stocks:" + stockTicker;
+    /**
+     * 사용 가능 주식 조회
+     */
+    private Long getCachedAvailableStocks(Long userId, String stockTicker) {
+        String stockKey = "user:" + userId + ":available_stocks:" + stockTicker;
         String stockStr = redisTemplate.opsForValue().get(stockKey);
         return stockStr != null ? Long.parseLong(stockStr) : DEFAULT_STOCKS;
     }
@@ -90,15 +103,40 @@ public class SettlementService {
         return exchangeRateStr != null ? Float.parseFloat(exchangeRateStr) : DEFAULT_EXCHANGE_RATE;
     }
 
-    private void updateBalance(Long userId, Long amount) {
-        String balanceKey = "user:" + userId + ":balance";
-        Long currentBalance = getCachedBalance(userId);
+
+    /**
+     * 사용 가능 예수금 업데이트
+     */
+    private void updateAvailableBalance(Long userId, Long amount) {
+        String balanceKey = "user:" + userId + ":available_balance";
+        Long currentBalance = getCachedAvailableBalance(userId);
         redisTemplate.opsForValue().set(balanceKey, String.valueOf(currentBalance + amount), 30, TimeUnit.DAYS);
     }
 
-    private void updateStocks(Long userId, String stockTicker, Long quantity) {
-        String stockKey = "user:" + userId + ":stocks:" + stockTicker;
-        Long currentStocks = getCachedStocks(userId, stockTicker);
+    /**
+     * 사용 가능 주식 업데이트
+     */
+    private void updateAvailableStocks(Long userId, String stockTicker, Long quantity) {
+        String stockKey = "user:" + userId + ":available_stocks:" + stockTicker;
+        Long currentStocks = getCachedAvailableStocks(userId, stockTicker);
+        redisTemplate.opsForValue().set(stockKey, String.valueOf(currentStocks + quantity), 30, TimeUnit.DAYS);
+    }
+
+    /**
+     * 실제 예수금 업데이트 (배치)
+     */
+    private void updateBalance(Long userId, Long amount) {
+        String balanceKey = "user:" + userId + ":balance";
+        Long currentBalance = getCachedAvailableBalance(userId);
+        redisTemplate.opsForValue().set(balanceKey, String.valueOf(currentBalance + amount), 30, TimeUnit.DAYS);
+    }
+
+    /**
+     * 보유 주식 업데이트 (배치)
+     */
+    private void updateHoldings(Long userId, String stockTicker, Long quantity) {
+        String stockKey = "user:" + userId + ":holdings:" + stockTicker;
+        Long currentStocks = getCachedAvailableStocks(userId, stockTicker);
         redisTemplate.opsForValue().set(stockKey, String.valueOf(currentStocks + quantity), 30, TimeUnit.DAYS);
     }
 

--- a/user-service/src/main/java/finpago/userservice/user/controller/UserController.java
+++ b/user-service/src/main/java/finpago/userservice/user/controller/UserController.java
@@ -39,7 +39,6 @@ public class UserController {
      */
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<String>> login(@RequestBody LoginReqDto loginReqDto) {
-        System.out.println("dd");
         String token = userService.login(loginReqDto);
         return ResponseEntity
                 .status(HttpStatus.OK)


### PR DESCRIPTION
## PR Type
- 기능 개선


## 해당 PR에 대한 설명

### 주문 가능 금액(available_balance) 및 보유 주식(available_stocks) 개념 추가

1) 주문 모듈(Order Service)에서 처리:
- 매수 주문 시 available_balance 즉시 차감 (실제 balance는 정산 시 차감)
- 매도 주문 시 available_stocks 즉시 차감 (실제 holdings는 정산 시 차감)

2) 정산 모듈(Settlement Service)에서 처리:
- 매수 완료 시 available_stocks 증가 + holdings 증가 (2일 후 배치 반영) + balance차감(2일 후 배치 반영)
- 매도 완료 시 available_balance 증가 + balance 증가 (2일 후 배치 반영) + holdings차감(2일 후 배치 반영)

### Redis Key 구조 개선

1) 주문 가능 금액과 실제 예수금을 분리

user:{userId}:available_balance → 즉시 반영되는 금액 (주문 후 차감)
user:{userId}:balance → D+2 배치에서 DB 반영

2) 사용 가능 주식과 보유 주식을 분리

user:{userId}:available_stocks:{stockTicker} → 즉시 차감 (주문 후 감소)
user:{userId}:holdings:{stockTicker} → D+2 배치에서 DB 반영

### 해결된 이슈
- 주문 후 체결 대기 상태에서도 UI에 즉시 반영할 수 있도록 개선
- 주문과 정산 간 시간 차이로 인한 혼선을 방지
- 실제 반영 금액(balance, holdings)과 사용자 화면에 표시되는 금액(available_balance, available_stocks)을 분리하여 정확성 향상
- 주문 후 즉시 UI 반영 + D+2 배치로 DB 부담 최소화
