### PR TITLE
P3-79(#70) [FIX]:  주문-정산 예수금, 주문가능금액, 보유주식, 매도가능주식 데이터 분리 및 미체결 주문 처리 개선

### DIFF
--- a/matching-service/src/main/java/finpago/matchingservice/matching/messaging/producer/MatchingProducer.java
+++ b/matching-service/src/main/java/finpago/matchingservice/matching/messaging/producer/MatchingProducer.java
@@ -1,5 +1,6 @@
 package finpago.matchingservice.matching.messaging.producer;
 
+import finpago.common.global.messaging.OrderCreateReqEvent;
 import finpago.common.global.messaging.TradeMatchingEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,10 +13,18 @@ import org.springframework.stereotype.Component;
 public class MatchingProducer {
 
     private final KafkaTemplate<String, TradeMatchingEvent> kafkaTemplate;
+    private final KafkaTemplate<String, OrderCreateReqEvent> orderKafkaTemplate;
+
     private static final String TRADE_MATCHING_TOPIC = "trade-matching-topic";
+    private static final String UNMATCHED_ORDER_TOPIC = "unmatched-order-topic"; // 미체결 주문을 Order 모듈로 전송
 
     public void sendTradeToExecution(TradeMatchingEvent tradeEvent) {
         kafkaTemplate.send(TRADE_MATCHING_TOPIC, tradeEvent);
         log.info("매칭된 주문을 Execution 모듈로 전송: {}", tradeEvent);
+    }
+
+    public void sendUnmatchedOrderToOrderService(OrderCreateReqEvent orderEvent) {
+        orderKafkaTemplate.send(UNMATCHED_ORDER_TOPIC, orderEvent);
+        log.warn("5분 동안 매칭되지 않은 주문을 Order 모듈로 재전송: {}", orderEvent);
     }
 }

--- a/matching-service/src/main/java/finpago/matchingservice/matching/service/MatchingService.java
+++ b/matching-service/src/main/java/finpago/matchingservice/matching/service/MatchingService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.PriorityQueue;
 import java.util.Comparator;
+import java.util.Queue;
 import java.util.UUID;
 
 @Service
@@ -22,36 +23,52 @@ public class MatchingService {
 
     // 매수 주문 (시간순 정렬)
     private final PriorityQueue<OrderCreateReqEvent> buyOrders = new PriorityQueue<>(
-            Comparator.comparing(OrderCreateReqEvent::getCreatedAt) // 먼저 들어온 주문이 먼저 매칭
+            Comparator.comparing(OrderCreateReqEvent::getCreatedAt)
     );
 
     // 매도 주문 (시간순 정렬)
     private final PriorityQueue<OrderCreateReqEvent> sellOrders = new PriorityQueue<>(
-            Comparator.comparing(OrderCreateReqEvent::getCreatedAt) //먼저 들어온 주문이 먼저 매칭
+            Comparator.comparing(OrderCreateReqEvent::getCreatedAt)
     );
 
+    // 미체결 주문 저장
+    private final Queue<OrderCreateReqEvent> unmatchedOrders = new PriorityQueue<>(
+            Comparator.comparing(OrderCreateReqEvent::getCreatedAt)
+    );
+
+    private static final long MAX_WAIT_TIME = 5 * 60 * 1000; // 5분 (밀리초 단위)
 
     public void processOrder(OrderCreateReqEvent order) {
-        System.out.println("Processing order: " + order);
+        log.info("주문 접수: {}", order);
+
         if (order.getOfferType() == OrderType.BUY) {
             buyOrders.offer(order);
-            System.out.println("Buy order: " + order);
+            log.info("매수 주문 추가: {}", order);
         } else {
             sellOrders.offer(order);
-            System.out.println("Sell order: " + order);
+            log.info("매도 주문 추가: {}", order);
         }
+
         processMatching();
     }
 
     private void processMatching() {
-        System.out.println("매칭시작");
-        System.out.println("buyOrders: " + buyOrders);
-        System.out.println("sellOrders: " + sellOrders);
+        log.info("매칭 시작");
+        long startTime = System.currentTimeMillis();
 
         while (!buyOrders.isEmpty() && !sellOrders.isEmpty()) {
+            // 5분이 지나면 미체결 주문을 Order 모듈로 전송
+            if (System.currentTimeMillis() - startTime > MAX_WAIT_TIME) {
+                log.warn("5분 초과 - 미체결 주문을 Order 모듈로 전송");
+
+                moveUnmatchedOrdersToQueue();
+                sendUnmatchedOrdersToOrderService();
+                return;
+            }
+
             OrderCreateReqEvent buyOrder = buyOrders.poll();
             OrderCreateReqEvent sellOrder = sellOrders.poll();
-            System.out.println("매칭조건확인시작");
+
             // 매칭 조건 확인: 매수 가격 >= 매도 가격
             if (buyOrder.getOfferPrice() >= sellOrder.getOfferPrice()) {
                 long matchedQuantity = Math.min(buyOrder.getOfferQuantity(), sellOrder.getOfferQuantity());
@@ -60,24 +77,23 @@ public class MatchingService {
                 buyOrder.setOfferQuantity(buyOrder.getOfferQuantity() - matchedQuantity);
                 sellOrder.setOfferQuantity(sellOrder.getOfferQuantity() - matchedQuantity);
 
-                System.out.println("체결모듈로 전달한 객체 생성시작");
                 // 체결된 주문을 Execution 모듈로 전달
                 TradeMatchingEvent tradeEvent = new TradeMatchingEvent(
-                        UUID.randomUUID(),               // 새로운 체결 ID
-                        buyOrder.getOfferNumber(),       // 매수 주문 ID
-                        sellOrder.getOfferNumber(),      // 매도 주문 ID
-                        buyOrder.getUserId(),            // 매수자 ID
-                        sellOrder.getUserId(),           // 매도자 ID
-                        buyOrder.getStockTicker(),       // 주식 티커
-                        matchedQuantity,                 // 체결 수량
-                        buyOrder.getOfferPrice(),        // 체결 가격
-                        LocalDateTime.now()              // 체결 시각
+                        UUID.randomUUID(),
+                        buyOrder.getOfferNumber(),
+                        sellOrder.getOfferNumber(),
+                        buyOrder.getUserId(),
+                        sellOrder.getUserId(),
+                        buyOrder.getStockTicker(),
+                        matchedQuantity,
+                        buyOrder.getOfferPrice(),
+                        LocalDateTime.now()
                 );
 
-                // Kafka Producer를 통해 Execution 모듈로 전송
                 matchingProducer.sendTradeToExecution(tradeEvent);
+                log.info("체결 완료 - Execution 모듈 전송: {}", tradeEvent);
 
-                // 부분 체결된 주문을 다시 정렬하여 삽입
+                // 부분 체결된 주문을 다시 삽입
                 if (buyOrder.getOfferQuantity() > 0) {
                     buyOrders.offer(buyOrder);
                 }
@@ -85,10 +101,41 @@ public class MatchingService {
                     sellOrders.offer(sellOrder);
                 }
             } else {
-                // 매칭이 안 된 주문은 다시 큐에 삽입
+                // 매칭이 안 된 주문은 다시 큐에 삽입 (5분 후 unmatchedOrders로 이동 예정)
                 buyOrders.offer(buyOrder);
                 sellOrders.offer(sellOrder);
             }
+        }
+
+        // 5분 초과 시 미체결 주문을 Order 모듈로 전송
+        if (System.currentTimeMillis() - startTime > MAX_WAIT_TIME) {
+            log.warn("5분 초과 - 미체결 주문을 Order 모듈로 전송");
+
+            moveUnmatchedOrdersToQueue();
+            sendUnmatchedOrdersToOrderService();
+        }
+    }
+
+    /**
+     * 매칭되지 않은 주문을 unmatchedOrders 큐로 이동
+     */
+    private void moveUnmatchedOrdersToQueue() {
+        while (!buyOrders.isEmpty()) {
+            unmatchedOrders.offer(buyOrders.poll());
+        }
+        while (!sellOrders.isEmpty()) {
+            unmatchedOrders.offer(sellOrders.poll());
+        }
+    }
+
+    /**
+     * 미체결 주문을 Order 모듈로 전송
+     */
+    private void sendUnmatchedOrdersToOrderService() {
+        while (!unmatchedOrders.isEmpty()) {
+            OrderCreateReqEvent unmatchedOrder = unmatchedOrders.poll();
+            matchingProducer.sendUnmatchedOrderToOrderService(unmatchedOrder);
+            log.info("미체결 주문 Order 모듈 전송: {}", unmatchedOrder);
         }
     }
 }

--- a/order-service/src/main/java/finpago/orderservice/order/config/kafka/KafkaRetryConfig.java
+++ b/order-service/src/main/java/finpago/orderservice/order/config/kafka/KafkaRetryConfig.java
@@ -15,7 +15,8 @@ import org.apache.kafka.common.TopicPartition;
 @Configuration
 public class KafkaRetryConfig {
 
-    private static final String DLT_TOPIC = "order-dlt-topic"; //DLT 토픽
+    private static final String ORDER_DLT_TOPIC = "order-dlt-topic";
+    private static final String UNMATCHED_ORDER_DLT_TOPIC = "unmatched-orders-dlt-topic";//DLT 토픽
     private static final long RETRY_INTERVAL = 1000L; // 재시도 간격 (1초)
     private static final int RETRY_COUNT = 3; // 최대 재시도 횟수
 
@@ -27,11 +28,17 @@ public class KafkaRetryConfig {
         ConcurrentKafkaListenerContainerFactory<String, OrderCreateReqEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory);
 
-        // 실패한 메시지를 DLT(Dead Letter Topic)으로 이동하는 Recoverer 설정
+        // DLT로 이동하는 ErrorHandler 설정
         DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
                 kafkaTemplate,
-                (ConsumerRecord<?, ?> record, Exception e) ->
-                        new TopicPartition(DLT_TOPIC, record.partition())
+                (ConsumerRecord<?, ?> record, Exception e) -> {
+                    String originalTopic = record.topic();
+                    if ("unmatched-orders-topic".equals(originalTopic)) {
+                        return new TopicPartition(UNMATCHED_ORDER_DLT_TOPIC, record.partition());
+                    } else {
+                        return new TopicPartition(ORDER_DLT_TOPIC, record.partition());
+                    }
+                }
         );
 
         // 3번 재시도 후 DLT로 이동하는 ErrorHandler

--- a/order-service/src/main/java/finpago/orderservice/order/messaging/consumer/OrderConsumer.java
+++ b/order-service/src/main/java/finpago/orderservice/order/messaging/consumer/OrderConsumer.java
@@ -1,0 +1,21 @@
+package finpago.orderservice.order.messaging.consumer;
+import finpago.common.global.messaging.OrderCreateReqEvent;
+import finpago.orderservice.order.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OrderConsumer {
+
+    private final OrderService orderService;
+
+    @KafkaListener(topics = "unmatched-orders-topic", groupId = "order-service-group")
+    public void handleUnmatchedOrder(OrderCreateReqEvent event) {
+        log.warn("미체결 주문 수신 - 다시 매칭 모듈로 전송 준비: {}", event);
+        orderService.retryUnmatchedOrder(event);
+    }
+}

--- a/order-service/src/main/java/finpago/orderservice/order/messaging/consumer/UnmatchedOrderDLTConsumer.java
+++ b/order-service/src/main/java/finpago/orderservice/order/messaging/consumer/UnmatchedOrderDLTConsumer.java
@@ -1,0 +1,38 @@
+package finpago.orderservice.order.messaging.consumer;
+
+import finpago.common.global.enums.OrderStatus;
+import finpago.common.global.messaging.OrderCreateReqEvent;
+import finpago.orderservice.order.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import finpago.orderservice.order.entity.Order;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UnmatchedOrderDLTConsumer {
+
+    private final OrderRepository orderRepository;
+
+    @KafkaListener(topics = "unmatched-orders-dlt-topic", groupId = "order-service-group")
+    public void handleUnmatchedOrderDLT(OrderCreateReqEvent event) {
+        log.error("DLT에서 미체결 주문 복구 시도 실패: {}", event.getOfferNumber());
+
+        UUID orderId = event.getOfferNumber();
+        Optional<Order> orderOptional = orderRepository.findById(orderId);
+
+        if (orderOptional.isPresent()) {
+            Order order = orderOptional.get();
+            order.setOfferStatus(OrderStatus.FAILED);
+            orderRepository.save(order);
+            log.warn("미체결 주문 최종 실패: 상태 FAILED로 변경됨: {}", orderId);
+        } else {
+            log.error("DLT에서 미체결 주문 처리 실패: 해당 주문을 찾을 수 없음: {}", orderId);
+        }
+    }
+}

--- a/order-service/src/main/java/finpago/orderservice/order/service/OrderService.java
+++ b/order-service/src/main/java/finpago/orderservice/order/service/OrderService.java
@@ -81,9 +81,9 @@ public class OrderService {
         }
 
         updateAvailableBalance(orderCreateReqDto.getUserId(), -requiredAmount);
-        updateBalance(orderCreateReqDto.getUserId(), -requiredAmount);
+//        updateBalance(orderCreateReqDto.getUserId(), -requiredAmount);
         updateAvailableStocks(orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker(), orderCreateReqDto.getOfferQuantity());
-        updateHoldings(orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker(), orderCreateReqDto.getOfferQuantity());
+//        updateHoldings(orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker(), orderCreateReqDto.getOfferQuantity());
     }
 
     /**
@@ -97,7 +97,7 @@ public class OrderService {
         }
 
         updateAvailableStocks(orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker(), -orderCreateReqDto.getOfferQuantity());
-        updateHoldings(orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker(), -orderCreateReqDto.getOfferQuantity());
+//        updateHoldings(orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker(), -orderCreateReqDto.getOfferQuantity());
         updateAvailableBalance(orderCreateReqDto.getUserId(), orderCreateReqDto.getOfferPrice() * orderCreateReqDto.getOfferQuantity());
     }
 

--- a/order-service/src/main/java/finpago/orderservice/order/service/OrderService.java
+++ b/order-service/src/main/java/finpago/orderservice/order/service/OrderService.java
@@ -28,6 +28,7 @@ public class OrderService {
 
     private static final long DEFAULT_BALANCE = 1_000_000L; // 기본 예수금
     private static final long DEFAULT_STOCKS = 100L; // 기본 보유 주식 수량
+    private static final long EXPIRATION_DAYS = 30; // Redis 데이터 보관 기간 (30일)
 
     @Transactional
     public UUID createOrder(Long userId, OrderCreateReqDto orderCreateReqDto) {
@@ -39,7 +40,6 @@ public class OrderService {
             validateAndDeductAvailableStocks(orderCreateReqDto);
         }
 
-        // 검증 통과 후 주문 저장 & Kafka 메시지 발행
         Order order = Order.builder()
                 .offerStatus(OrderStatus.CREATED)
                 .offerType(orderType)
@@ -63,9 +63,9 @@ public class OrderService {
         );
 
         orderProducer.sendOrder(event);
-
         return order.getOfferNumber();
     }
+
 
     /**
      * 매수 주문 시 사용 가능 예수금 검증 후 차감
@@ -75,14 +75,13 @@ public class OrderService {
         Long requiredAmount = orderCreateReqDto.getOfferPrice() * orderCreateReqDto.getOfferQuantity();
 
         if (availableBalance < requiredAmount) {
-            log.error("예수금 부족 - User ID: {}, 필요 금액: {}, 보유 금액: {}",
-                    orderCreateReqDto.getUserId(), requiredAmount, availableBalance);
             throw new InsufficientBalanceException("예수금이 부족합니다");
         }
 
-        // 사용 가능 예수금 차감
         updateAvailableBalance(orderCreateReqDto.getUserId(), -requiredAmount);
-        log.info("매수 주문 - 사용 가능 예수금 차감: 사용자 {}, 차감 금액 {}", orderCreateReqDto.getUserId(), requiredAmount);
+        updateBalance(orderCreateReqDto.getUserId(), -requiredAmount);
+        updateAvailableStocks(orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker(), orderCreateReqDto.getOfferQuantity());
+        updateHoldings(orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker(), orderCreateReqDto.getOfferQuantity());
     }
 
     /**
@@ -92,50 +91,57 @@ public class OrderService {
         Long availableStocks = getCachedAvailableStocks(orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker());
 
         if (availableStocks < orderCreateReqDto.getOfferQuantity()) {
-            log.error("보유 주식 부족 - User ID: {}, 필요 주식: {}, 보유 주식: {}",
-                    orderCreateReqDto.getUserId(), orderCreateReqDto.getOfferQuantity(), availableStocks);
             throw new InsufficientStockException("보유 주식이 부족합니다");
         }
 
-        // 사용 가능 주식 차감
         updateAvailableStocks(orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker(), -orderCreateReqDto.getOfferQuantity());
-        log.info("매도 주문 - 사용 가능 주식 차감: 사용자 {}, 종목 {}, 차감 수량 {}",
-                orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker(), orderCreateReqDto.getOfferQuantity());
+        updateHoldings(orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker(), -orderCreateReqDto.getOfferQuantity());
+        updateAvailableBalance(orderCreateReqDto.getUserId(), orderCreateReqDto.getOfferPrice() * orderCreateReqDto.getOfferQuantity());
     }
 
-    /**
-     * 사용 가능 예수금 조회
-     */
     private Long getCachedAvailableBalance(Long userId) {
-        String balanceKey = "user:" + userId + ":available_balance";
-        String balanceStr = redisTemplate.opsForValue().get(balanceKey);
-        return balanceStr != null ? Long.parseLong(balanceStr) : DEFAULT_BALANCE;
+        String key = "user:" + userId + ":available_balance";
+        return redisTemplate.opsForValue().get(key) != null ? Long.parseLong(redisTemplate.opsForValue().get(key)) : DEFAULT_BALANCE;
     }
 
-    /**
-     * 사용 가능 주식 조회
-     */
     private Long getCachedAvailableStocks(Long userId, String stockTicker) {
-        String stockKey = "user:" + userId + ":available_stocks:" + stockTicker;
-        String stockStr = redisTemplate.opsForValue().get(stockKey);
-        return stockStr != null ? Long.parseLong(stockStr) : DEFAULT_STOCKS;
+        String key = "user:" + userId + ":available_stocks:" + stockTicker;
+        return redisTemplate.opsForValue().get(key) != null ? Long.parseLong(redisTemplate.opsForValue().get(key)) : DEFAULT_STOCKS;
     }
 
     /**
-     * 사용 가능 예수금 업데이트
+     * 사용 가능 예수금 업데이트 (30일 보관)
      */
     private void updateAvailableBalance(Long userId, Long amount) {
-        String balanceKey = "user:" + userId + ":available_balance";
-        Long currentBalance = getCachedAvailableBalance(userId);
-        redisTemplate.opsForValue().set(balanceKey, String.valueOf(currentBalance + amount), 5, TimeUnit.MINUTES);
+        String key = "user:" + userId + ":available_balance";
+        Long current = getCachedAvailableBalance(userId);
+        redisTemplate.opsForValue().set(key, String.valueOf(current + amount), EXPIRATION_DAYS, TimeUnit.DAYS);
     }
 
     /**
-     * 사용 가능 주식 업데이트
+     * 실제 예수금 업데이트 (30일 보관)
+     */
+    private void updateBalance(Long userId, Long amount) {
+        String key = "user:" + userId + ":balance";
+        Long current = getCachedAvailableBalance(userId);
+        redisTemplate.opsForValue().set(key, String.valueOf(current + amount), EXPIRATION_DAYS, TimeUnit.DAYS);
+    }
+
+    /**
+     * 사용 가능 주식 업데이트 (30일 보관)
      */
     private void updateAvailableStocks(Long userId, String stockTicker, Long quantity) {
-        String stockKey = "user:" + userId + ":available_stocks:" + stockTicker;
-        Long currentStocks = getCachedAvailableStocks(userId, stockTicker);
-        redisTemplate.opsForValue().set(stockKey, String.valueOf(currentStocks + quantity), 5, TimeUnit.MINUTES);
+        String key = "user:" + userId + ":available_stocks:" + stockTicker;
+        Long current = getCachedAvailableStocks(userId, stockTicker);
+        redisTemplate.opsForValue().set(key, String.valueOf(current + quantity), EXPIRATION_DAYS, TimeUnit.DAYS);
+    }
+
+    /**
+     * 보유 주식 업데이트 (30일 보관)
+     */
+    private void updateHoldings(Long userId, String stockTicker, Long quantity) {
+        String key = "user:" + userId + ":holdings:" + stockTicker;
+        Long current = getCachedAvailableStocks(userId, stockTicker);
+        redisTemplate.opsForValue().set(key, String.valueOf(current + quantity), EXPIRATION_DAYS, TimeUnit.DAYS);
     }
 }

--- a/order-service/src/main/java/finpago/orderservice/order/service/OrderService.java
+++ b/order-service/src/main/java/finpago/orderservice/order/service/OrderService.java
@@ -13,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.springframework.transaction.annotation.Transactional;
@@ -143,5 +145,37 @@ public class OrderService {
         String key = "user:" + userId + ":holdings:" + stockTicker;
         Long current = getCachedAvailableStocks(userId, stockTicker);
         redisTemplate.opsForValue().set(key, String.valueOf(current + quantity), EXPIRATION_DAYS, TimeUnit.DAYS);
+    }
+
+    @Transactional
+    public void retryUnmatchedOrder(OrderCreateReqEvent event) {
+        UUID orderId = event.getOfferNumber();
+        Optional<Order> existingOrder = orderRepository.findById(orderId);
+
+        Order order;
+        if (existingOrder.isPresent()) {
+            // 기존 주문이 있으면 상태만 PENDING으로 변경
+            order = existingOrder.get();
+            order.setOfferStatus(OrderStatus.PENDING);
+            log.info("기존 주문 PENDING 상태로 업데이트: {}", order);
+        } else {
+            // 주문이 존재하지 않으면 새로 저장
+            order = Order.builder()
+                    .offerNumber(orderId)
+                    .userId(event.getUserId())
+                    .offerType(event.getOfferType())
+                    .offerQuantity(event.getOfferQuantity())
+                    .offerPrice(event.getOfferPrice())
+                    .stockTicker(event.getStockTicker())
+                    .offerStatus(OrderStatus.PENDING) // PENDING 상태로 설정
+                    .build();
+            log.info("새로운 미체결 주문 저장: {}", order);
+        }
+
+        orderRepository.save(order);
+
+        // 다시 매칭 모듈로 전송
+        orderProducer.sendOrder(event);
+        log.info("미체결 주문을 매칭 모듈로 재전송 완료: {}", event);
     }
 }

--- a/settlement-service/src/main/java/finpago/settlementservice/settlement/service/SettlementService.java
+++ b/settlement-service/src/main/java/finpago/settlementservice/settlement/service/SettlementService.java
@@ -31,16 +31,10 @@ public class SettlementService {
         // Redis에서 환율 조회 (없을 경우 기본값 적용)
         Float exchangeRate = getExchangeRate(event.getStockTicker());
 
-        // 매수자(BUY) 처리
-        updateBalance(event.getBuyerUserId(), -event.getTradePrice() * event.getTradeQuantity()); // 실제 예수금 감소
-        updateAvailableStocks(event.getBuyerUserId(), event.getStockTicker(), event.getTradeQuantity()); // 사용 가능 주식 증가
-        updateHoldings(event.getBuyerUserId(), event.getStockTicker(), event.getTradeQuantity()); // 보유 주식 증가 (배치)
+        //매수자는 처리할거없음 주문 모듈에서 다 처리함
 
         // 매도자(SELL) 처리
-        updateAvailableBalance(event.getSellerUserId(), event.getTradePrice() * event.getTradeQuantity()); // 사용 가능 예수금 증가
         updateBalance(event.getSellerUserId(), event.getTradePrice() * event.getTradeQuantity()); // 실제 예수금 증가 (배치)
-        updateAvailableStocks(event.getSellerUserId(), event.getStockTicker(), -event.getTradeQuantity()); // 사용 가능 주식 감소
-        updateHoldings(event.getSellerUserId(), event.getStockTicker(), -event.getTradeQuantity()); // 보유 주식 감소 (즉시 반영)
 
         // 환차손익 저장
         updateStockForFxTracking(event.getBuyerUserId(), event.getStockTicker(), event.getTradeQuantity(), exchangeRate);
@@ -103,25 +97,6 @@ public class SettlementService {
         return exchangeRateStr != null ? Float.parseFloat(exchangeRateStr) : DEFAULT_EXCHANGE_RATE;
     }
 
-
-    /**
-     * 사용 가능 예수금 업데이트
-     */
-    private void updateAvailableBalance(Long userId, Long amount) {
-        String balanceKey = "user:" + userId + ":available_balance";
-        Long currentBalance = getCachedAvailableBalance(userId);
-        redisTemplate.opsForValue().set(balanceKey, String.valueOf(currentBalance + amount), 30, TimeUnit.DAYS);
-    }
-
-    /**
-     * 사용 가능 주식 업데이트
-     */
-    private void updateAvailableStocks(Long userId, String stockTicker, Long quantity) {
-        String stockKey = "user:" + userId + ":available_stocks:" + stockTicker;
-        Long currentStocks = getCachedAvailableStocks(userId, stockTicker);
-        redisTemplate.opsForValue().set(stockKey, String.valueOf(currentStocks + quantity), 30, TimeUnit.DAYS);
-    }
-
     /**
      * 실제 예수금 업데이트 (배치)
      */
@@ -130,16 +105,6 @@ public class SettlementService {
         Long currentBalance = getCachedAvailableBalance(userId);
         redisTemplate.opsForValue().set(balanceKey, String.valueOf(currentBalance + amount), 30, TimeUnit.DAYS);
     }
-
-    /**
-     * 보유 주식 업데이트 (배치)
-     */
-    private void updateHoldings(Long userId, String stockTicker, Long quantity) {
-        String stockKey = "user:" + userId + ":holdings:" + stockTicker;
-        Long currentStocks = getCachedAvailableStocks(userId, stockTicker);
-        redisTemplate.opsForValue().set(stockKey, String.valueOf(currentStocks + quantity), 30, TimeUnit.DAYS);
-    }
-
 
     /**
      * 환차손익 계산을 위해 체결 당시 환율 및 수량을 Redis에 저장

--- a/settlement-service/src/main/java/finpago/settlementservice/settlement/service/SettlementService.java
+++ b/settlement-service/src/main/java/finpago/settlementservice/settlement/service/SettlementService.java
@@ -33,13 +33,15 @@ public class SettlementService {
         Float exchangeRate = getExchangeRate(event.getStockTicker());
 
         //매수자
-        updateBalance(event.getSellerUserId(), -event.getTradePrice() * event.getTradeQuantity());// 실제 예수금 감소
+        updateBatchBalance(event.getBuyerUserId(), -event.getTradePrice() * event.getTradeQuantity());
+        updateBalance(event.getBuyerUserId(), -event.getTradePrice() * event.getTradeQuantity());// 실제 예수금 감소
         updateHoldings(event.getBuyerUserId(), event.getStockTicker(), event.getTradeQuantity()); // 보유 주식 증가 (배치)
-        
+
+
         // 매도자
         updateBatchBalance(event.getSellerUserId(), event.getTradePrice() * event.getTradeQuantity());//배치용증가
 //        updateBalance(event.getSellerUserId(), event.getTradePrice() * event.getTradeQuantity()); //사용자에게 보여지는 출금가능 예수금은 그대로
-        updateHoldings(event.getBuyerUserId(), event.getStockTicker(), -event.getTradeQuantity()); // 보유 주식 감소 (배치)
+        updateHoldings(event.getSellerUserId(), event.getStockTicker(), -event.getTradeQuantity()); // 보유 주식 감소 (배치)
 
         // 환차손익 저장
         updateStockForFxTracking(event.getBuyerUserId(), event.getStockTicker(), event.getTradeQuantity(), exchangeRate);

--- a/settlement-service/src/main/java/finpago/settlementservice/settlement/service/SettlementService.java
+++ b/settlement-service/src/main/java/finpago/settlementservice/settlement/service/SettlementService.java
@@ -22,6 +22,7 @@ public class SettlementService {
     private static final long DEFAULT_BALANCE = 1_000_000L; // 기본 예수금
     private static final long DEFAULT_STOCKS = 1000000; // 기본 보유 주식 수량
     private static final float DEFAULT_EXCHANGE_RATE = 1.0f; // 기본 환율 (1.0)
+    private static final long EXPIRATION_DAYS = 30; // Redis 데이터 보관 기간 (30일)
 
     @Transactional
     public void processSettlement(TradeMatchingEvent event) {
@@ -31,10 +32,14 @@ public class SettlementService {
         // Redis에서 환율 조회 (없을 경우 기본값 적용)
         Float exchangeRate = getExchangeRate(event.getStockTicker());
 
-        //매수자는 처리할거없음 주문 모듈에서 다 처리함
-
-        // 매도자(SELL) 처리
-        updateBalance(event.getSellerUserId(), event.getTradePrice() * event.getTradeQuantity()); // 실제 예수금 증가 (배치)
+        //매수자
+        updateBalance(event.getSellerUserId(), -event.getTradePrice() * event.getTradeQuantity());// 실제 예수금 감소
+        updateHoldings(event.getBuyerUserId(), event.getStockTicker(), event.getTradeQuantity()); // 보유 주식 증가 (배치)
+        
+        // 매도자
+        updateBatchBalance(event.getSellerUserId(), event.getTradePrice() * event.getTradeQuantity());//배치용증가
+//        updateBalance(event.getSellerUserId(), event.getTradePrice() * event.getTradeQuantity()); //사용자에게 보여지는 출금가능 예수금은 그대로
+        updateHoldings(event.getBuyerUserId(), event.getStockTicker(), -event.getTradeQuantity()); // 보유 주식 감소 (배치)
 
         // 환차손익 저장
         updateStockForFxTracking(event.getBuyerUserId(), event.getStockTicker(), event.getTradeQuantity(), exchangeRate);
@@ -97,14 +102,54 @@ public class SettlementService {
         return exchangeRateStr != null ? Float.parseFloat(exchangeRateStr) : DEFAULT_EXCHANGE_RATE;
     }
 
+
+    /**
+     * 사용 가능 예수금 업데이트
+     */
+    private void updateAvailableBalance(Long userId, Long amount) {
+        String balanceKey = "user:" + userId + ":available_balance";
+        Long currentBalance = getCachedAvailableBalance(userId);
+        redisTemplate.opsForValue().set(balanceKey, String.valueOf(currentBalance + amount), EXPIRATION_DAYS, TimeUnit.DAYS);
+    }
+
+    /**
+     * 사용 가능 주식 업데이트
+     */
+    private void updateAvailableStocks(Long userId, String stockTicker, Long quantity) {
+        String stockKey = "user:" + userId + ":available_stocks:" + stockTicker;
+        Long currentStocks = getCachedAvailableStocks(userId, stockTicker);
+        redisTemplate.opsForValue().set(stockKey, String.valueOf(currentStocks + quantity), EXPIRATION_DAYS, TimeUnit.DAYS);
+    }
+
     /**
      * 실제 예수금 업데이트 (배치)
      */
     private void updateBalance(Long userId, Long amount) {
         String balanceKey = "user:" + userId + ":balance";
         Long currentBalance = getCachedAvailableBalance(userId);
-        redisTemplate.opsForValue().set(balanceKey, String.valueOf(currentBalance + amount), 30, TimeUnit.DAYS);
+        redisTemplate.opsForValue().set(balanceKey, String.valueOf(currentBalance + amount), EXPIRATION_DAYS, TimeUnit.DAYS);
     }
+
+    /**
+     * 배치 계산용 예수금 업데이트 (D+2일 반영용)
+     * - 실제 balance 업데이트를 위한 중간 저장소 역할
+     * - 사용자가 직접 조회하는 출금 가능 예수금과는 별도로 관리됨
+     */
+    private void updateBatchBalance(Long userId, Long amount) {
+        String batchBalanceKey = "user:" + userId + ":batch_balance";
+        Long currentBalance = getCachedAvailableBalance(userId);
+        redisTemplate.opsForValue().set(batchBalanceKey, String.valueOf(currentBalance + amount), EXPIRATION_DAYS, TimeUnit.DAYS);
+    }
+
+    /**
+     * 보유 주식 업데이트 (배치)
+     */
+    private void updateHoldings(Long userId, String stockTicker, Long quantity) {
+        String stockKey = "user:" + userId + ":holdings:" + stockTicker;
+        Long currentStocks = getCachedAvailableStocks(userId, stockTicker);
+        redisTemplate.opsForValue().set(stockKey, String.valueOf(currentStocks + quantity), EXPIRATION_DAYS, TimeUnit.DAYS);
+    }
+
 
     /**
      * 환차손익 계산을 위해 체결 당시 환율 및 수량을 Redis에 저장

--- a/user-service/src/main/java/finpago/userservice/user/service/TradingSettlementBatchService.java
+++ b/user-service/src/main/java/finpago/userservice/user/service/TradingSettlementBatchService.java
@@ -32,15 +32,14 @@ public class TradingSettlementBatchService {
         LocalDate executionDate = LocalDate.now().plusDays(2); // D+2 저장
         String pendingUpdateKey = "pending_update:" + executionDate;
 
-        Set<String> balanceKeys = redisTemplate.keys("user:*:balance");
+        Set<String> balanceKeys = redisTemplate.keys("user:*:batch_balance"); // 배치 계산용 예수금 사용
         if (balanceKeys == null || balanceKeys.isEmpty()) {
             log.warn("예약할 사용자 예수금 데이터 없음");
             return;
         }
 
         for (String balanceKey : balanceKeys) {
-
-            String userId = balanceKey.split(":")[1]; // user:{userId}:balance
+            String userId = balanceKey.split(":")[1]; // user:{userId}:batch_balance
             String balanceStr = redisTemplate.opsForValue().get(balanceKey);
 
             if (balanceStr != null) {


### PR DESCRIPTION
## PR Type
- 주문-정산 데이터 분리 및 미체결 주문 처리 개선

## 해당 PR에 대한 설명

## 미체결 주문 처리 로직 추가
- 매칭 모듈에서 주문이 5분간 체결되지 않으면 미체결로 간주하고, 주문 모듈로 전송 -> 사용자에게 미체결 주문 보여주기 위해서
- 주문 모듈에서 미체결 주문을 수신한 후 다시 매칭 모듈로 전송하여 재매칭 시도

##  매수·매도 시 예수금 및 보유 주식 처리 방식 개선

### 주문 모듈(Order Service) 개선

 매수 주문 시:
- available_balance 차감 (출금 불가한 주문 가능 예수금)
- available_stocks 증가

매도 주문 시:
- available_stocks 차감 (매도 주문 가능 주식)
- available_balance 증가

### 정산 모듈(Settlement Service) 개선

매수 체결 시:
- holdings 증가
- balance는 감소
- 배치용batch_balance 감소

매도 체결 시:
- 배치용batch_balance 증가
- 사용자에게 보일 출금가능 금액인 balance은 증가하지않음 
- holdings 감소

