### PR TITLE
P3-74(#70) [FIX]: 배치 작업시 사용자 실제 예수금 업데이트 및 실제 보유 주식 업데이트

### DIFF
--- a/settlement-service/src/main/java/finpago/settlementservice/settlement/service/SettlementService.java
+++ b/settlement-service/src/main/java/finpago/settlementservice/settlement/service/SettlementService.java
@@ -124,7 +124,7 @@ public class SettlementService {
     }
 
     /**
-     * 실제 예수금 업데이트 (배치)
+     * 실제 예수금 업데이트
      */
     private void updateBalance(Long userId, Long amount) {
         String balanceKey = "user:" + userId + ":balance";

--- a/user-service/src/main/java/finpago/userservice/user/service/TradingSettlementBatchService.java
+++ b/user-service/src/main/java/finpago/userservice/user/service/TradingSettlementBatchService.java
@@ -21,6 +21,7 @@ public class TradingSettlementBatchService {
     private final StringRedisTemplate redisTemplate;
     private final AccountRepository accountRepository;
     private final HoldingsRepository holdingsRepository;
+    private static final long EXPIRATION_DAYS = 30;
 
     /**
      * 매일 00:00 실행 → 2일 후(D+2)에 업데이트할 데이터 저장 (예약)
@@ -88,9 +89,14 @@ public class TradingSettlementBatchService {
             String balanceStr = redisTemplate.opsForValue().get(balanceKey);
 
             if (balanceStr != null) {
-                Long newBalance = Long.parseLong(balanceStr);
-                accountRepository.updateAccountWithholding(Long.parseLong(userId), newBalance);
+                String newBalance = balanceStr;
+                accountRepository.updateAccountWithholding(Long.parseLong(userId), Long.parseLong(newBalance));
+
                 log.info("사용자 {} 예수금 DB 업데이트 (D+2 반영): {}", userId, newBalance);
+                String userBalanceKey = "user:" + userId + ":balance";
+
+                redisTemplate.opsForValue().set(userBalanceKey, newBalance, EXPIRATION_DAYS, TimeUnit.DAYS);
+                log.info("Redis 사용자 {} 실제 예수금 업데이트: {}", userId, newBalance);
             }
 
             Set<String> stockKeys = redisTemplate.keys(pendingUpdateKey + ":stocks:" + userId + ":*");
@@ -106,13 +112,17 @@ public class TradingSettlementBatchService {
 
                         holdingsRepository.updateHoldings(Long.parseLong(userId), stockTicker, newQuantity, totalPrice);
                         log.info("사용자 {}의 {} 보유량 DB 업데이트 (D+2 반영): {}주 (총 {}원)", userId, stockTicker, newQuantity, totalPrice);
+
+                        String userStockKey = "user:" + userId + ":holdings:" + stockTicker;
+                        redisTemplate.opsForValue().set(userStockKey, quantityStr, EXPIRATION_DAYS, TimeUnit.DAYS);
+                        log.info("Redis 사용자 {} 실제 보유 주식 업데이트: {} - {}주", userId, stockTicker, newQuantity);
                     }
                 }
             }
         }
 
-        // D-2 데이터 삭제 (불필요한 데이터 정리)
-        redisTemplate.delete(balanceKeys);
+//        // D-2 데이터 삭제 (불필요한 데이터 정리)
+//        redisTemplate.delete(balanceKeys);
         log.info("[D+2 반영 배치 완료]");
     }
 


### PR DESCRIPTION
## PR Type
- 수정


## 해당 PR에 대한 설명
- 배치 작업시 사용자 실제 예수금 업데이트 및 실제 보유 주식 업데이트
- 매일밤 12시 배치 작업 진행 후 사용자에게 보여지는 사용가능 예수금을 2일전 batch처리로 정산된 값으로 업데이트 해줍니다