### PR TITLE
P3-87(#88) [FEAT]: 예수금, 사용가능예수금, 보유주식, 매도가능주식 조회 api

### DIFF
--- a/order-service/src/main/java/finpago/orderservice/order/controller/OrderController.java
+++ b/order-service/src/main/java/finpago/orderservice/order/controller/OrderController.java
@@ -22,25 +22,16 @@ public class OrderController {
     private final OrderService orderService;
 
     /**
-     * 🔹매수/매도 주문 요청
+     * 매수/매도 주문 요청
      *
      * @param orderCreateReqDto 주문 정보 DTO
      * @return 주문 생성 결과
      */
     @PostMapping("/create")
-    public ResponseEntity<ApiResponse<String>> createOrder(
-            @RequestBody OrderCreateReqDto orderCreateReqDto) {
-
+    public ResponseEntity<ApiResponse<String>> createOrder(@RequestBody OrderCreateReqDto orderCreateReqDto) {
         System.out.println("주문 생성 요청 수신됨");
 
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication == null || authentication.getPrincipal() == "anonymousUser") {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(ApiResponse.fail(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자"));
-        }
-
-        Long userId = Long.parseLong(authentication.getName());
+        Long userId = getUserIdFromAuth();
         System.out.println("인증된 사용자 ID: " + userId);
 
         UUID offerNumber = orderService.createOrder(userId, orderCreateReqDto);
@@ -49,6 +40,19 @@ public class OrderController {
                 .body(ApiResponse.success(HttpStatus.CREATED, "주문 생성 완료", offerNumber.toString()));
     }
 
+
+    /**
+     * 인증된 사용자 ID 가져오기
+     */
+    private Long getUserIdFromAuth() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getPrincipal().equals("anonymousUser")) {
+            throw new IllegalStateException("인증되지 않은 사용자");
+        }
+
+        return Long.parseLong(authentication.getName());
+    }
 }
 //@RestController
 //@RequestMapping("/v1/api/order")

--- a/order-service/src/main/java/finpago/orderservice/order/dto/OrderCreateReqDto.java
+++ b/order-service/src/main/java/finpago/orderservice/order/dto/OrderCreateReqDto.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 @Getter
 public class OrderCreateReqDto {
     private Long orderId;
-    private Long userId;
     private Long offerQuantity;
     private Long offerPrice;
     private String stockTicker;

--- a/order-service/src/main/java/finpago/orderservice/order/service/OrderService.java
+++ b/order-service/src/main/java/finpago/orderservice/order/service/OrderService.java
@@ -28,8 +28,8 @@ public class OrderService {
     private final OrderProducer orderProducer;
     private final StringRedisTemplate redisTemplate;
 
-    private static final long DEFAULT_BALANCE = 1_000_000L; // 기본 예수금
-    private static final long DEFAULT_STOCKS = 100L; // 기본 보유 주식 수량
+    private static final long DEFAULT_BALANCE = 10000000; // 기본 예수금
+    private static final long DEFAULT_STOCKS = 100; // 기본 보유 주식 수량
     private static final long EXPIRATION_DAYS = 30; // Redis 데이터 보관 기간 (30일)
 
     @Transactional
@@ -37,9 +37,9 @@ public class OrderService {
         OrderType orderType = OrderType.valueOf(orderCreateReqDto.getOfferType());
 
         if (orderType == OrderType.BUY) {
-            validateAndDeductAvailableBalance(orderCreateReqDto);
+            validateAndDeductAvailableBalance(userId,orderCreateReqDto);
         } else if (orderType == OrderType.SELL) {
-            validateAndDeductAvailableStocks(orderCreateReqDto);
+            validateAndDeductAvailableStocks(userId,orderCreateReqDto);
         }
 
         Order order = Order.builder()
@@ -72,33 +72,38 @@ public class OrderService {
     /**
      * 매수 주문 시 사용 가능 예수금 검증 후 차감
      */
-    private void validateAndDeductAvailableBalance(OrderCreateReqDto orderCreateReqDto) {
-        Long availableBalance = getCachedAvailableBalance(orderCreateReqDto.getUserId());
+    private void validateAndDeductAvailableBalance(Long userId,OrderCreateReqDto orderCreateReqDto) {
+        Long availableBalance = getCachedAvailableBalance(userId);
         Long requiredAmount = orderCreateReqDto.getOfferPrice() * orderCreateReqDto.getOfferQuantity();
+
+        System.out.println("캐싱된사용가능예수금:"+availableBalance);
+        System.out.println("필요한 돈이용:"+requiredAmount);
 
         if (availableBalance < requiredAmount) {
             throw new InsufficientBalanceException("예수금이 부족합니다");
         }
 
-        updateAvailableBalance(orderCreateReqDto.getUserId(), -requiredAmount);
+        updateAvailableBalance(userId, -requiredAmount);
 //        updateBalance(orderCreateReqDto.getUserId(), -requiredAmount);
-        updateAvailableStocks(orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker(), orderCreateReqDto.getOfferQuantity());
+        updateAvailableStocks(userId, orderCreateReqDto.getStockTicker(), orderCreateReqDto.getOfferQuantity());
 //        updateHoldings(orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker(), orderCreateReqDto.getOfferQuantity());
     }
 
     /**
      * 매도 주문 시 사용 가능 주식 검증 후 차감
      */
-    private void validateAndDeductAvailableStocks(OrderCreateReqDto orderCreateReqDto) {
-        Long availableStocks = getCachedAvailableStocks(orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker());
+    private void validateAndDeductAvailableStocks(Long userId, OrderCreateReqDto orderCreateReqDto) {
+        Long availableStocks = getCachedAvailableStocks(userId, orderCreateReqDto.getStockTicker());
+
+        System.out.println("캐싱된사용가능 주식수:"+availableStocks);
 
         if (availableStocks < orderCreateReqDto.getOfferQuantity()) {
             throw new InsufficientStockException("보유 주식이 부족합니다");
         }
 
-        updateAvailableStocks(orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker(), -orderCreateReqDto.getOfferQuantity());
+        updateAvailableStocks(userId, orderCreateReqDto.getStockTicker(), -orderCreateReqDto.getOfferQuantity());
 //        updateHoldings(orderCreateReqDto.getUserId(), orderCreateReqDto.getStockTicker(), -orderCreateReqDto.getOfferQuantity());
-        updateAvailableBalance(orderCreateReqDto.getUserId(), orderCreateReqDto.getOfferPrice() * orderCreateReqDto.getOfferQuantity());
+        updateAvailableBalance(userId, orderCreateReqDto.getOfferPrice() * orderCreateReqDto.getOfferQuantity());
     }
 
     private Long getCachedAvailableBalance(Long userId) {
@@ -115,6 +120,9 @@ public class OrderService {
      * 사용 가능 예수금 업데이트 (30일 보관)
      */
     private void updateAvailableBalance(Long userId, Long amount) {
+        System.out.println("유저아이딩: " + userId);
+        System.out.println("돈은용: " + amount);
+
         String key = "user:" + userId + ":available_balance";
         Long current = getCachedAvailableBalance(userId);
         redisTemplate.opsForValue().set(key, String.valueOf(current + amount), EXPIRATION_DAYS, TimeUnit.DAYS);
@@ -133,6 +141,9 @@ public class OrderService {
      * 사용 가능 주식 업데이트 (30일 보관)
      */
     private void updateAvailableStocks(Long userId, String stockTicker, Long quantity) {
+        System.out.println("유저아이딩: " + userId);
+        System.out.println("주식종목은용: " + stockTicker);
+        System.out.println("수량은용: " + quantity);
         String key = "user:" + userId + ":available_stocks:" + stockTicker;
         Long current = getCachedAvailableStocks(userId, stockTicker);
         redisTemplate.opsForValue().set(key, String.valueOf(current + quantity), EXPIRATION_DAYS, TimeUnit.DAYS);

--- a/settlement-service/src/main/java/finpago/settlementservice/settlement/service/SettlementService.java
+++ b/settlement-service/src/main/java/finpago/settlementservice/settlement/service/SettlementService.java
@@ -19,8 +19,8 @@ public class SettlementService {
     private final StringRedisTemplate redisTemplate;
     private final SettlementProducer settlementProducer;
 
-    private static final long DEFAULT_BALANCE = 1_000_000L; // 기본 예수금
-    private static final long DEFAULT_STOCKS = 1000000; // 기본 보유 주식 수량
+    private static final long DEFAULT_BALANCE = 10000000; // 기본 예수금
+    private static final long DEFAULT_STOCKS = 100; // 기본 보유 주식 수량
     private static final float DEFAULT_EXCHANGE_RATE = 1.0f; // 기본 환율 (1.0)
     private static final long EXPIRATION_DAYS = 30; // Redis 데이터 보관 기간 (30일)
 
@@ -84,7 +84,7 @@ public class SettlementService {
      * 사용 가능 예수금 조회
      */
     private Long getCachedAvailableBalance(Long userId) {
-        String balanceKey = "user:" + userId + ":available_balance";
+        String balanceKey = "user:" + userId + ":balance";
         String balanceStr = redisTemplate.opsForValue().get(balanceKey);
         return balanceStr != null ? Long.parseLong(balanceStr) : DEFAULT_BALANCE;
     }
@@ -93,7 +93,7 @@ public class SettlementService {
      * 사용 가능 주식 조회
      */
     private Long getCachedAvailableStocks(Long userId, String stockTicker) {
-        String stockKey = "user:" + userId + ":available_stocks:" + stockTicker;
+        String stockKey = "user:" + userId + ":holdings:" + stockTicker;
         String stockStr = redisTemplate.opsForValue().get(stockKey);
         return stockStr != null ? Long.parseLong(stockStr) : DEFAULT_STOCKS;
     }

--- a/user-service/src/main/java/finpago/userservice/account/controller/AccountController.java
+++ b/user-service/src/main/java/finpago/userservice/account/controller/AccountController.java
@@ -1,0 +1,56 @@
+package finpago.userservice.account.controller;
+
+import finpago.common.global.common.ApiResponse;
+import finpago.userservice.account.service.AccountService;
+import finpago.userservice.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/api/account")
+@RequiredArgsConstructor
+public class AccountController {
+
+    private final AccountService accountService;
+
+    /**
+     * 사용 가능 예수금 조회
+     */
+    @GetMapping("/available-balance")
+    public ResponseEntity<ApiResponse<Long>> getAvailableBalance() {
+        Long userId = getUserIdFromAuth();
+        Long availableBalance = accountService.getAvailableBalance(userId);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "사용 가능 예수금 조회 성공", availableBalance));
+    }
+
+    /**
+     * 실제 예수금 조회 (출금 가능 예수금)
+     */
+    @GetMapping("/balance")
+    public ResponseEntity<ApiResponse<Long>> getBalance() {
+        Long userId = getUserIdFromAuth();
+        Long balance = accountService.getBalance(userId);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "실제 예수금 조회 성공", balance));
+    }
+
+    /**
+     * 인증된 사용자 ID 가져오기
+     */
+    private Long getUserIdFromAuth() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getPrincipal() == "anonymousUser") {
+            throw new IllegalStateException("인증되지 않은 사용자");
+        }
+
+        return Long.parseLong(authentication.getName());
+    }
+}

--- a/user-service/src/main/java/finpago/userservice/account/service/AccountService.java
+++ b/user-service/src/main/java/finpago/userservice/account/service/AccountService.java
@@ -1,0 +1,35 @@
+package finpago.userservice.account.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AccountService {
+
+    private final StringRedisTemplate redisTemplate;
+    private static final long DEFAULT_BALANCE = 10000000; // 기본 예수금
+    private static final long DEFAULT_STOCKS = 100; // 기본 보유 주식 수량 // 기본 예수금
+
+
+    /**
+     * 사용 가능 예수금 조회
+     */
+    public Long getAvailableBalance(Long userId) {
+        String key = "user:" + userId + ":available_balance";
+        String value = redisTemplate.opsForValue().get(key);
+        return value != null ? Long.parseLong(value) : DEFAULT_BALANCE;
+    }
+
+    /**
+     * 실제 예수금 조회
+     */
+    public Long getBalance(Long userId) {
+        String key = "user:" + userId + ":balance";
+        String value = redisTemplate.opsForValue().get(key);
+        return value != null ? Long.parseLong(value) : DEFAULT_BALANCE;
+    }
+}

--- a/user-service/src/main/java/finpago/userservice/holdings/controller/HoldingController.java
+++ b/user-service/src/main/java/finpago/userservice/holdings/controller/HoldingController.java
@@ -1,0 +1,56 @@
+package finpago.userservice.holdings.controller;
+
+import finpago.common.global.common.ApiResponse;
+import finpago.userservice.holdings.service.HoldingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/api/stocks")
+@RequiredArgsConstructor
+public class HoldingController {
+
+    private final HoldingService holdingService;
+
+    /**
+     * 사용 가능 주식 조회 (해당 종목)
+     */
+    @GetMapping("/available-stocks/{stockTicker}")
+    public ResponseEntity<ApiResponse<Long>> getAvailableStocks(@PathVariable String stockTicker) {
+        Long userId = getUserIdFromAuth();
+        Long availableStocks = holdingService.getAvailableStocks(userId, stockTicker);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "사용 가능 주식 조회 성공", availableStocks));
+    }
+
+    /**
+     * 보유 주식 조회 (해당 종목)
+     */
+    @GetMapping("/holdings/{stockTicker}")
+    public ResponseEntity<ApiResponse<Long>> getHoldings(@PathVariable String stockTicker) {
+        Long userId = getUserIdFromAuth();
+        Long holdings = holdingService.getHoldings(userId, stockTicker);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "보유 주식 조회 성공", holdings));
+    }
+
+    /**
+     * 인증된 사용자 ID 가져오기
+     */
+    private Long getUserIdFromAuth() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getPrincipal() == "anonymousUser") {
+            throw new IllegalStateException("인증되지 않은 사용자");
+        }
+
+        return Long.parseLong(authentication.getName());
+    }
+}

--- a/user-service/src/main/java/finpago/userservice/holdings/service/HoldingService.java
+++ b/user-service/src/main/java/finpago/userservice/holdings/service/HoldingService.java
@@ -1,0 +1,34 @@
+package finpago.userservice.holdings.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class HoldingService {
+
+    private final StringRedisTemplate redisTemplate;
+    private static final long DEFAULT_BALANCE = 10000000; // 기본 예수금
+    private static final long DEFAULT_STOCKS = 100; // 기본 보유 주식 수량
+
+    /**
+     * 사용 가능 주식 조회
+     */
+    public Long getAvailableStocks(Long userId, String stockTicker) {
+        String key = "user:" + userId + ":available_stocks:" + stockTicker;
+        String value = redisTemplate.opsForValue().get(key);
+        return value != null ? Long.parseLong(value) : DEFAULT_STOCKS;
+    }
+
+    /**
+     * 보유 주식 조회
+     */
+    public Long getHoldings(Long userId, String stockTicker) {
+        String key = "user:" + userId + ":holdings:" + stockTicker;
+        String value = redisTemplate.opsForValue().get(key);
+        return value != null ? Long.parseLong(value) : DEFAULT_STOCKS;
+    }
+}

--- a/user-service/src/main/java/finpago/userservice/user/service/RedisDummyDataInitializer.java
+++ b/user-service/src/main/java/finpago/userservice/user/service/RedisDummyDataInitializer.java
@@ -16,9 +16,9 @@ public class RedisDummyDataInitializer {
 
     private final StringRedisTemplate redisTemplate;
 
-    private static final long DEFAULT_BALANCE = 1_000_000L; // 기본 예수금
-    private static final long DEFAULT_STOCKS = 100L; // 기본 보유 주식 수량
-    private static final long DEFAULT_PRICE = 50_000L; // 기본 종목 가격
+    private static final long DEFAULT_BALANCE = 10000000; // 기본 예수금
+    private static final long DEFAULT_STOCKS = 100; // 기본 보유 주식 수량
+    private static final long DEFAULT_PRICE = 5000; // 기본 종목 가격
     private static final int EXPIRATION_DAYS = 10; // 데이터 보관 기간
 
     @PostConstruct
@@ -29,20 +29,20 @@ public class RedisDummyDataInitializer {
         String executionDate = LocalDate.now().toString();
 
         // 사용자 예수금 더미 데이터 (배치 반영을 위한 batch_balance 사용)
-        String balanceKey1 = "pending_update:" + executionDate + ":batch_balance:9";
-        String balanceKey2 = "pending_update:" + executionDate + ":batch_balance:10";
+        String balanceKey1 = "pending_update:" + executionDate + ":batch_balance:10";
+        String balanceKey2 = "pending_update:" + executionDate + ":batch_balance:11";
         redisTemplate.opsForValue().set(balanceKey1, String.valueOf(DEFAULT_BALANCE), EXPIRATION_DAYS, TimeUnit.DAYS);
-        redisTemplate.opsForValue().set(balanceKey2, String.valueOf(DEFAULT_BALANCE + 500000), EXPIRATION_DAYS, TimeUnit.DAYS);
+        redisTemplate.opsForValue().set(balanceKey2, String.valueOf(DEFAULT_BALANCE), EXPIRATION_DAYS, TimeUnit.DAYS);
 
         // 사용자 보유 주식 더미 데이터 (holdings 기준으로 저장)
-        String stockKey1 = "pending_update:" + executionDate + ":holdings:9:TSLA";
-        String stockKey2 = "pending_update:" + executionDate + ":holdings:9:AAPL";
+        String stockKey1 = "pending_update:" + executionDate + ":holdings:10:TSLA";
+        String stockKey2 = "pending_update:" + executionDate + ":holdings:10:AAPL";
         redisTemplate.opsForValue().set(stockKey1, String.valueOf(DEFAULT_STOCKS), EXPIRATION_DAYS, TimeUnit.DAYS);
-        redisTemplate.opsForValue().set(stockKey2, String.valueOf(DEFAULT_STOCKS - 10), EXPIRATION_DAYS, TimeUnit.DAYS);
+        redisTemplate.opsForValue().set(stockKey2, String.valueOf(DEFAULT_STOCKS), EXPIRATION_DAYS, TimeUnit.DAYS);
 
         // 종목 가격 더미 데이터 (30일 보관)
         redisTemplate.opsForValue().set("stock:TSLA:price", String.valueOf(DEFAULT_PRICE), 30, TimeUnit.DAYS);
-        redisTemplate.opsForValue().set("stock:AAPL:price", String.valueOf(DEFAULT_PRICE + 20000), 30, TimeUnit.DAYS);
+        redisTemplate.opsForValue().set("stock:AAPL:price", String.valueOf(DEFAULT_PRICE), 30, TimeUnit.DAYS);
 
         log.info("[Redis 초기 더미 데이터 삽입 완료]");
     }


### PR DESCRIPTION
## PR Type
- 기능추가

## 해당 PR에 대한 설명


## 스크린샷

<매도자>
1. 출금가능 예수금 (balance)
![image](https://github.com/user-attachments/assets/8cb040f0-0d01-4d3e-978e-768e83d53fcf)
매도시 출금 가능한 실제 예수금이 바로 증가되지않음
D+2일에 배치 처리에 의해 증가됨 -> 기존값으로 보여짐

2. 사용가능 예수금(available-balance)
![image](https://github.com/user-attachments/assets/9af1b730-3499-4744-8451-d7c1ded67a87)
하지만 사용자에게 보여지는 주식 매수시 사용가능 예수금의 경우 증가된 상태로 다른 주식을 살수있음

3. 보유주식(holdings),매도가능주식(available-holdings) 
![image](https://github.com/user-attachments/assets/5a541bd3-f568-4764-8dec-de763488b3dc)
![image](https://github.com/user-attachments/assets/34298cab-da53-4a54-ae40-6abc09efab7f)
보유주식(수량 잘못 찍혔는데 99맞습니다)
보유주식 -> D+2일에 배치 처리될 보유주식
매도가능 주식 -> 사용자 화면에 보여지는 현재 보유주식


