### PR TITLE
P3-90(#90) [FEAT]: redis에서 체결데이터 가져와서 내주문과 비교후 체결 처리

### DIFF
--- a/common/src/main/java/finpago/common/global/exception/handler/GlobalExceptionHandler.java
+++ b/common/src/main/java/finpago/common/global/exception/handler/GlobalExceptionHandler.java
@@ -8,10 +8,14 @@ if (userBalance.compareTo(orderAmount) < 0) {
 import finpago.common.global.exception.dto.CommonResponse;
 import finpago.common.global.exception.dto.ErrorResponse;
 import finpago.common.global.exception.error.*;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
 
 @RestControllerAdvice
 @Slf4j
@@ -227,11 +231,45 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(errorCode.getStatus()).body(response);
     }
 
-    // 예상치 못한 예외 처리
+//    // 예상치 못한 예외 처리
+//    @ExceptionHandler(Exception.class)
+//    protected ResponseEntity<CommonResponse> handleGeneralException(Exception exception) {
+//        log.error("[서버 오류] {}", exception.getMessage());
+//
+//        ErrorResponse error = ErrorResponse.builder()
+//                .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus().value())
+//                .message(ErrorCode.INTERNAL_SERVER_ERROR.getMessage())
+//                .code(ErrorCode.INTERNAL_SERVER_ERROR.getCode())
+//                .build();
+//
+//        CommonResponse response = CommonResponse.builder()
+//                .success(false)
+//                .error(error)
+//                .build();
+//
+//        return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus()).body(response);
+//    }
+
     @ExceptionHandler(Exception.class)
-    protected ResponseEntity<CommonResponse> handleGeneralException(Exception exception) {
+    protected ResponseEntity<?> handleGeneralException(Exception exception, HttpServletRequest request) {
         log.error("[서버 오류] {}", exception.getMessage());
 
+        // SSE 요청인지 확인
+        if ("text/event-stream".equals(request.getHeader("Accept"))) {
+            log.error("SSE 요청 중 예외 발생: {}", exception.getMessage());
+
+            SseEmitter emitter = new SseEmitter();
+            try {
+                emitter.send("event: error\ndata: SSE 요청 중 오류 발생 - " + exception.getMessage() + "\n\n");
+                emitter.complete();
+            } catch (IOException e) {
+                emitter.completeWithError(e);
+            }
+
+            return ResponseEntity.internalServerError().build();
+        }
+
+        // 일반 HTTP 요청에 대한 응답 처리
         ErrorResponse error = ErrorResponse.builder()
                 .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus().value())
                 .message(ErrorCode.INTERNAL_SERVER_ERROR.getMessage())

--- a/execution-service/src/main/java/finpago/executionservice/ExecutionServiceApplication.java
+++ b/execution-service/src/main/java/finpago/executionservice/ExecutionServiceApplication.java
@@ -5,9 +5,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableDiscoveryClient
 @SpringBootApplication
+@EnableScheduling
 @ComponentScan(basePackages = {"finpago.common.global.exception", "finpago.executionservice"})
 public class ExecutionServiceApplication {
 

--- a/execution-service/src/main/java/finpago/executionservice/execution/config/auth/SecurityConfig.java
+++ b/execution-service/src/main/java/finpago/executionservice/execution/config/auth/SecurityConfig.java
@@ -23,9 +23,11 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .cors(cors -> cors.disable())
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // ✅ 세션 사용 X
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/v1/api/trade/updates/**").permitAll()
                         .anyRequest().authenticated() // 모든 API에 대해 JWT 인증 필요
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class); // JWT 필터 추가

--- a/execution-service/src/main/java/finpago/executionservice/execution/config/cors/CorsConfig.java
+++ b/execution-service/src/main/java/finpago/executionservice/execution/config/cors/CorsConfig.java
@@ -1,0 +1,24 @@
+package finpago.executionservice.execution.config.cors;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**") // 모든 API 엔드포인트에 대해 CORS 허용
+                        .allowedOriginPatterns("*") // 모든 도메인 허용 (필요 시 특정 도메인으로 변경 가능)
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS") // 허용할 HTTP 메서드
+                        .allowCredentials(false) // 인증 정보 포함 여부 (SSE에서는 false 가능)
+                        .maxAge(3600); // 캐시 시간 (1시간)
+            }
+        };
+    }
+}

--- a/execution-service/src/main/java/finpago/executionservice/execution/messaging/consumer/ExecutionConsumer.java
+++ b/execution-service/src/main/java/finpago/executionservice/execution/messaging/consumer/ExecutionConsumer.java
@@ -2,6 +2,7 @@ package finpago.executionservice.execution.messaging.consumer;
 
 import finpago.common.global.messaging.TradeMatchingEvent;
 import finpago.executionservice.execution.service.ExecutionService;
+//import finpago.executionservice.executionChart.service.SseEmitterService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Component;
 public class ExecutionConsumer {
 
     private final ExecutionService executionService;
+//    private final SseEmitterService sseEmitterService;
 
     @KafkaListener(topics = "trade-matching-topic", groupId = "execution-service-group",
             containerFactory = "kafkaRetryListenerContainerFactory")
@@ -27,5 +29,16 @@ public class ExecutionConsumer {
         log.warn("정산 실패 처리: {}", event);
         executionService.handleSettlementFailure(event);
     }
+
+//    @KafkaListener(topics = "settlement-topic", groupId = "execution-service-group",
+//            containerFactory = "kafkaRetryListenerContainerFactory")
+//    public void consumeSettlementEvent(TradeMatchingEvent event) {
+//        log.info("[체결창] : 체결 이벤트 수신 - 주식 {}: {}", event.getStockTicker(), event);
+//
+//        log.info("[체결창] : 체결 금액은용11 {}", event.getTradePrice());
+//        // 주식 티커별 SSE 전송 (tradeQuantity, tradePrice만 포함)
+//        sseEmitterService.sendTradeUpdate(event.getStockTicker(), event.getTradeQuantity(), event.getTradePrice());
+//        log.info("[체결창] : 체결 금액은용22 {}", event.getTradePrice());
+//    }
 
 }

--- a/execution-service/src/main/java/finpago/executionservice/executionChart/controller/TradeSseController.java
+++ b/execution-service/src/main/java/finpago/executionservice/executionChart/controller/TradeSseController.java
@@ -1,0 +1,45 @@
+//package finpago.executionservice.executionChart.controller;
+//
+//import finpago.executionservice.executionChart.service.SseEmitterService;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.web.bind.annotation.*;
+//import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+//
+//import java.io.IOException;
+//
+//@RestController
+//@RequestMapping("/v1/api/trade")
+//@RequiredArgsConstructor
+//@Slf4j
+//public class TradeSseController {
+//
+//    private final SseEmitterService sseEmitterService;
+//
+//    /**
+//     * 특정 주식 티커의 실시간 체결 정보를 SSE로 구독
+//     */
+//    @CrossOrigin(origins = "*")
+//    @GetMapping("/updates/{stockTicker}")
+//    public SseEmitter getTradeUpdates(@PathVariable String stockTicker) {
+//        log.info("📡 SSE 연결 요청: {}", stockTicker);
+//
+//        try {
+//            // 타임아웃을 null로 설정하여 무제한 유지
+//            SseEmitter emitter = sseEmitterService.createEmitter(stockTicker);
+//            return emitter;
+//        } catch (Exception e) {
+//            log.error("❌ SSE 요청 중 예외 발생: {}", e.getMessage());
+//
+//            // 클라이언트가 SSE 오류를 감지할 수 있도록 직접 전송 후 complete()
+//            SseEmitter errorEmitter = new SseEmitter(0L);
+//            try {
+//                errorEmitter.send("event: error\ndata: SSE 요청 중 오류 발생 - " + e.getMessage() + "\n\n");
+//                errorEmitter.complete();
+//            } catch (IOException ioException) {
+//                errorEmitter.completeWithError(ioException);
+//            }
+//            return errorEmitter;
+//        }
+//    }
+//}

--- a/execution-service/src/main/java/finpago/executionservice/executionChart/service/SseEmitterService.java
+++ b/execution-service/src/main/java/finpago/executionservice/executionChart/service/SseEmitterService.java
@@ -1,0 +1,66 @@
+//package finpago.executionservice.executionChart.service;
+//
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.scheduling.annotation.Scheduled;
+//import org.springframework.stereotype.Service;
+//import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+//
+//import java.io.IOException;
+//import java.util.Map;
+//import java.util.concurrent.ConcurrentHashMap;
+//
+//@Service
+//@Slf4j
+//public class SseEmitterService {
+//
+//    // 주식 티커별 SSE Emitter 저장
+//    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+//
+//    /**
+//     * 주식 티커별 SSE 연결 생성
+//     */
+//    public SseEmitter createEmitter(String stockTicker) {
+//        SseEmitter emitter = new SseEmitter(null);
+//        emitters.put(stockTicker, emitter);
+//
+//        emitter.onCompletion(() -> emitters.remove(stockTicker));
+//        emitter.onTimeout(() -> emitters.remove(stockTicker));
+//
+//        log.info("주식 {} SSE 연결 생성", stockTicker);
+//        return emitter;
+//    }
+//
+//    /**
+//     * 체결 정보를 주식 티커별로 실시간 전송
+//     */
+//    public void sendTradeUpdate(String stockTicker, Long tradeQuantity, Long tradePrice) {
+//        SseEmitter emitter = emitters.get(stockTicker);
+//
+//        if (emitter != null) {
+//            try {
+//                emitter.send(SseEmitter.event()
+//                        .name("trade-update")
+//                        .data(Map.of(
+//                                "tradeQuantity", tradeQuantity,
+//                                "tradePrice", tradePrice
+//                        )));
+//                log.info("주식 {} 체결 정보 전송: 수량 {} | 가격 {}", stockTicker, tradeQuantity, tradePrice);
+//            } catch (IOException e) {
+//                log.error("주식 {} 체결 정보 전송 실패", stockTicker);
+//                emitters.remove(stockTicker);
+//            }
+//        }
+//    }
+//
+//    @Scheduled(fixedRate = 1000) // 1초마다 실행
+//    public void sendPingToClients() {
+//        for (SseEmitter emitter : emitters.values()) {
+//            try {
+//                emitter.send(SseEmitter.event().name("ping").data("💓"));
+//            } catch (IOException e) {
+//                emitter.complete();
+//            }
+//        }
+//    }
+//
+//}

--- a/execution-service/src/main/resources/index.html
+++ b/execution-service/src/main/resources/index.html
@@ -1,0 +1,49 @@
+<!--<!DOCTYPE html>-->
+<!--<html lang="ko">-->
+<!--<head>-->
+<!--    <meta charset="UTF-8">-->
+<!--    <meta name="viewport" content="width=device-width, initial-scale=1.0">-->
+<!--    <title>체결 내역 SSE 테스트</title>-->
+<!--</head>-->
+<!--<body>-->
+<!--<h1>실시간 체결 내역</h1>-->
+<!--<div id="trade-log"></div>-->
+
+<!--<script>-->
+<!--    const stockTicker = "TSL";  // 구독하려는 주식 티커-->
+<!--    let eventSource;-->
+
+<!--    function connectSSE() {-->
+<!--        console.log("📡 SSE 연결 시도...");-->
+<!--        eventSource = new EventSource(`http://localhost:19095/v1/api/trade/updates/${stockTicker}`);-->
+
+<!--        eventSource.addEventListener("trade-update", (event) => {-->
+<!--            const tradeData = JSON.parse(event.data);-->
+<!--            console.log(`📩 체결 내역 (${stockTicker}):`, tradeData);-->
+
+<!--            // UI 업데이트-->
+<!--            const logDiv = document.getElementById("trade-log");-->
+<!--            logDiv.innerHTML += `<p>📈 ${tradeData.tradeQuantity}주 - ${tradeData.tradePrice}원</p>`;-->
+<!--        });-->
+
+<!--        eventSource.addEventListener("ping", () => {-->
+<!--            console.log("💓 SSE ping 이벤트 수신 (연결 유지)");-->
+<!--        });-->
+
+<!--        eventSource.onerror = (error) => {-->
+<!--            console.error("❌ SSE 연결 오류", error);-->
+<!--            eventSource.close();  // 현재 연결 닫기-->
+
+<!--            // 10초 후 자동 재연결-->
+<!--            setTimeout(() => {-->
+<!--                console.log("🔄 SSE 재연결 시도...");-->
+<!--                connectSSE();-->
+<!--            }, 10000);-->
+<!--        };-->
+<!--    }-->
+
+<!--    // 최초 실행-->
+<!--    connectSSE();-->
+<!--</script>-->
+<!--</body>-->
+<!--</html>-->

--- a/matching-service/build.gradle
+++ b/matching-service/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 
     //kafka
     implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/matching-service/src/main/java/finpago/matchingservice/matching/service/MatchingService.java
+++ b/matching-service/src/main/java/finpago/matchingservice/matching/service/MatchingService.java
@@ -1,5 +1,6 @@
 package finpago.matchingservice.matching.service;
 
+import org.springframework.data.redis.core.StringRedisTemplate;
 import finpago.common.global.enums.OrderType;
 import finpago.common.global.messaging.OrderCreateReqEvent;
 import finpago.common.global.messaging.TradeMatchingEvent;
@@ -9,10 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.PriorityQueue;
-import java.util.Comparator;
-import java.util.Queue;
-import java.util.UUID;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +18,7 @@ import java.util.UUID;
 public class MatchingService {
 
     private final MatchingProducer matchingProducer;
+    private final StringRedisTemplate redisTemplate;
 
     // 매수 주문 (시간순 정렬)
     private final PriorityQueue<OrderCreateReqEvent> buyOrders = new PriorityQueue<>(
@@ -57,10 +56,8 @@ public class MatchingService {
         long startTime = System.currentTimeMillis();
 
         while (!buyOrders.isEmpty() && !sellOrders.isEmpty()) {
-            // 5분이 지나면 미체결 주문을 Order 모듈로 전송
             if (System.currentTimeMillis() - startTime > MAX_WAIT_TIME) {
                 log.warn("5분 초과 - 미체결 주문을 Order 모듈로 전송");
-
                 moveUnmatchedOrdersToQueue();
                 sendUnmatchedOrdersToOrderService();
                 return;
@@ -69,55 +66,105 @@ public class MatchingService {
             OrderCreateReqEvent buyOrder = buyOrders.poll();
             OrderCreateReqEvent sellOrder = sellOrders.poll();
 
-            // 매칭 조건 확인: 매수 가격 >= 매도 가격
-            if (buyOrder.getOfferPrice() >= sellOrder.getOfferPrice()) {
-                Long buyerOrderQuentity=buyOrder.getOfferQuantity();
-                Long sellerOrderQuentity=sellOrder.getOfferQuantity();
-                long matchedQuantity = Math.min(buyOrder.getOfferQuantity(), sellOrder.getOfferQuantity());
+            // Redis에서 해당 주식 티커의 체결 가능 데이터를 가져옴
+            Map<String, Object> redisTrade = getMatchingTradeFromRedis(buyOrder.getStockTicker());
+            if (redisTrade != null) {
+                long redisPrice = (long) redisTrade.get("price");
+                long redisVolume = (long) redisTrade.get("volume");
 
-                // 부분 체결 발생
-                buyOrder.setOfferQuantity(buyOrder.getOfferQuantity() - matchedQuantity);
-                sellOrder.setOfferQuantity(sellOrder.getOfferQuantity() - matchedQuantity);
+                log.info("Redis 체결 데이터 발견 - 가격: {}, 수량: {}", redisPrice, redisVolume);
 
-                // 체결된 주문을 Execution 모듈로 전달
-                TradeMatchingEvent tradeEvent = new TradeMatchingEvent(
-                        UUID.randomUUID(),
-                        buyOrder.getOfferNumber(),
-                        sellOrder.getOfferNumber(),
-                        buyOrder.getUserId(),
-                        sellOrder.getUserId(),
-                        buyOrder.getStockTicker(),
-                        matchedQuantity,
-                        buyOrder.getOfferPrice(),
-                        LocalDateTime.now(),
-                        buyerOrderQuentity, // 매수자가 원래 주문한 수량
-                        sellerOrderQuentity  // 매도자가 원래 주문한 수량
-                );
+                // 현재 주문과 Redis 체결 데이터를 비교하여 매칭 수행
+                if (buyOrder.getOfferPrice() >= redisPrice && sellOrder.getOfferPrice() <= redisPrice) {
+                    long matchedQuantity = Math.min(Math.min(buyOrder.getOfferQuantity(), sellOrder.getOfferQuantity()), redisVolume);
 
-                matchingProducer.sendTradeToExecution(tradeEvent);
-                log.info("체결 완료 - Execution 모듈 전송: {}", tradeEvent);
-
-                // 부분 체결된 주문을 다시 삽입
-                if (buyOrder.getOfferQuantity() > 0) {
-                    buyOrders.offer(buyOrder);
-                }
-                if (sellOrder.getOfferQuantity() > 0) {
-                    sellOrders.offer(sellOrder);
+                    // 체결 처리
+                    handleTradeExecution(buyOrder, sellOrder, matchedQuantity, redisPrice);
+                } else {
+                    log.info(" Redis 데이터와 매칭 불가 - 기존 매칭 로직 수행");
+                    matchOrders(buyOrder, sellOrder);
                 }
             } else {
-                // 매칭이 안 된 주문은 다시 큐에 삽입 (5분 후 unmatchedOrders로 이동 예정)
-                buyOrders.offer(buyOrder);
-                sellOrders.offer(sellOrder);
+                log.info("Redis 체결 데이터 없음 - 기존 매칭 로직 수행");
+                matchOrders(buyOrder, sellOrder);
             }
         }
 
-        // 5분 초과 시 미체결 주문을 Order 모듈로 전송
         if (System.currentTimeMillis() - startTime > MAX_WAIT_TIME) {
             log.warn("5분 초과 - 미체결 주문을 Order 모듈로 전송");
-
             moveUnmatchedOrdersToQueue();
             sendUnmatchedOrdersToOrderService();
         }
+    }
+
+    /**
+     * 기존 매칭 로직
+     */
+    private void matchOrders(OrderCreateReqEvent buyOrder, OrderCreateReqEvent sellOrder) {
+        if (buyOrder.getOfferPrice() >= sellOrder.getOfferPrice()) {
+            long matchedQuantity = Math.min(buyOrder.getOfferQuantity(), sellOrder.getOfferQuantity());
+
+            handleTradeExecution(buyOrder, sellOrder, matchedQuantity, buyOrder.getOfferPrice());
+        } else {
+            buyOrders.offer(buyOrder);
+            sellOrders.offer(sellOrder);
+        }
+    }
+
+    /**
+     * 체결된 주문을 Execution 모듈로 전달
+     */
+    private void handleTradeExecution(OrderCreateReqEvent buyOrder, OrderCreateReqEvent sellOrder, long matchedQuantity, long matchedPrice) {
+        Long buyerOrderQuantity = buyOrder.getOfferQuantity();
+        Long sellerOrderQuantity = sellOrder.getOfferQuantity();
+
+        buyOrder.setOfferQuantity(buyOrder.getOfferQuantity() - matchedQuantity);
+        sellOrder.setOfferQuantity(sellOrder.getOfferQuantity() - matchedQuantity);
+
+        TradeMatchingEvent tradeEvent = new TradeMatchingEvent(
+                UUID.randomUUID(),
+                buyOrder.getOfferNumber(),
+                sellOrder.getOfferNumber(),
+                buyOrder.getUserId(),
+                sellOrder.getUserId(),
+                buyOrder.getStockTicker(),
+                matchedQuantity,
+                matchedPrice,
+                LocalDateTime.now(),
+                buyerOrderQuantity,
+                sellerOrderQuantity
+        );
+
+        matchingProducer.sendTradeToExecution(tradeEvent);
+        log.info("체결 완료 - Execution 모듈 전송: {}", tradeEvent);
+
+        if (buyOrder.getOfferQuantity() > 0) {
+            buyOrders.offer(buyOrder);
+        }
+        if (sellOrder.getOfferQuantity() > 0) {
+            sellOrders.offer(sellOrder);
+        }
+    }
+
+    /**
+     * Redis에서 주어진 주식 티커의 최신 체결 데이터 가져오기
+     */
+    private Map<String, Object> getMatchingTradeFromRedis(String stockTicker) {
+        String redisKey = "stock:" + stockTicker + ":purchase";
+        List<String> tradeList = redisTemplate.opsForList().range(redisKey, 0, 1);
+
+        if (tradeList != null && !tradeList.isEmpty()) {
+            String tradeJson = tradeList.get(0);
+            try {
+                return Map.of(
+                        "price", Long.parseLong(tradeJson.split(",")[0].split(":")[1].trim()), // 체결가
+                        "volume", Long.parseLong(tradeJson.split(",")[1].split(":")[1].trim()) // 체결량
+                );
+            } catch (Exception e) {
+                log.error("Redis 체결 데이터 파싱 오류: {}", e.getMessage());
+            }
+        }
+        return null;
     }
 
     /**

--- a/matching-service/src/main/resources/application-dev.yml
+++ b/matching-service/src/main/resources/application-dev.yml
@@ -1,6 +1,10 @@
 spring:
   application:
     name: matching-service
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 server:
   port: 19094

--- a/notification-service/src/main/resources/application-dev.yml
+++ b/notification-service/src/main/resources/application-dev.yml
@@ -1,6 +1,10 @@
 spring:
   application:
     name: notification-service
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 server:
   port: 19097

--- a/order-service/src/main/java/finpago/orderservice/OrderServiceApplication.java
+++ b/order-service/src/main/java/finpago/orderservice/OrderServiceApplication.java
@@ -5,9 +5,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableDiscoveryClient
 @SpringBootApplication
+@EnableScheduling
 @ComponentScan(basePackages = {"finpago.common.global.exception", "finpago.orderservice"})
 public class OrderServiceApplication {
 

--- a/order-service/src/main/java/finpago/orderservice/order/dto/OrderCreateReqDto.java
+++ b/order-service/src/main/java/finpago/orderservice/order/dto/OrderCreateReqDto.java
@@ -1,10 +1,12 @@
 package finpago.orderservice.order.dto;
 
 import lombok.Getter;
+import lombok.Setter;
 
+@Setter
 @Getter
 public class OrderCreateReqDto {
-    private Long orderId;
+//    private Long orderId;
     private Long offerQuantity;
     private Long offerPrice;
     private String stockTicker;


### PR DESCRIPTION
## PR Type
- Redis 체결 데이터와 사용자 주문 매칭 로직 개선

## 해당 PR에 대한 설명

### 실제 체결 데이터(Redis)와 사용자 주문 데이터(트레이딩 시스템)를 통합하여 매칭 로직 개선
- Redis에서 실시간 체결 내역(체결가, 체결량) 조회 후, 주문과 비교하여 매칭 가능 여부 판단
- 매칭 가능하면 Redis 체결가 기준으로 체결 처리, 불가능하면 기존 매칭 로직 수행
- 체결 내역을 MatchingService에서 Execution 모듈로 전송하여 사용자 체결 창에 반영

기존에 하려고했던 SSE코드는 임시 주석 처리되었습니다
실제 해외 주식은 국내 주식보다 체결 빈도가 낮아서 0.5~1초 단위 조회면 충분히 실시간 경험 제공 가능하다고 판단하여
redis로 처리하였습니다