### PR TITLE
P3-102(#100) [FIX]: 유저모듈에서 kafka 설정에서 traderetryfactory와 noticeretryfactory분리

### DIFF
--- a/matching-service/src/main/java/finpago/matchingservice/matching/messaging/consumer/MatchingConsumer.java
+++ b/matching-service/src/main/java/finpago/matchingservice/matching/messaging/consumer/MatchingConsumer.java
@@ -16,13 +16,15 @@ public class MatchingConsumer {
     private static final String ORDER_TOPIC = "order-topic";
     private static final String FAILED_EXECUTION_TOPIC = "failed-execution-topic";
 
-    @KafkaListener(topics = ORDER_TOPIC, groupId = "matching-service-group")
+    @KafkaListener(topics = ORDER_TOPIC, groupId = "matching-service-group",
+            containerFactory = "kafkaRetryListenerContainerFactory")
     public void handleNewOrder(OrderCreateReqEvent order) {
         log.info("새 주문 매칭 모듈에서 수신: {}", order);
         matchingService.processOrder(order);
     }
 
-    @KafkaListener(topics = FAILED_EXECUTION_TOPIC, groupId = "matching-service-group")
+    @KafkaListener(topics = FAILED_EXECUTION_TOPIC, groupId = "matching-service-group",
+            containerFactory = "kafkaRetryListenerContainerFactory")
     public void handleFailedTrade(OrderCreateReqEvent failedOrder) {
         log.warn("체결 실패 주문 재매칭: {}", failedOrder);
         matchingService.processOrder(failedOrder); // 실패 주문을 다시 매칭 큐에 삽입

--- a/user-service/src/main/java/finpago/userservice/holdings/messaging/consumer/HoldingsConsumer.java
+++ b/user-service/src/main/java/finpago/userservice/holdings/messaging/consumer/HoldingsConsumer.java
@@ -16,7 +16,7 @@ public class HoldingsConsumer {
     private static final String SETTLEMENT_TOPIC = "settlement-topic";
 
     @KafkaListener(topics = SETTLEMENT_TOPIC, groupId = "holding-service-group",
-            containerFactory = "kafkaRetryListenerContainerFactory")
+            containerFactory = "tradeMatchingKafkaRetryListenerContainerFactory")
     public void handleTradeExecution(TradeMatchingEvent event) {
         log.info("체결된 주문 유저 모듈에서 수신: {}", event);
         holdingService.updateHoldings(event);

--- a/user-service/src/main/java/finpago/userservice/user/config/kafka/KafkaConfig.java
+++ b/user-service/src/main/java/finpago/userservice/user/config/kafka/KafkaConfig.java
@@ -32,7 +32,7 @@ public class KafkaConfig {
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
-        props.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, true);
+        props.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
         return new DefaultKafkaProducerFactory<>(props);
     }
 
@@ -118,7 +118,6 @@ public class KafkaConfig {
         return factory;
     }
 
-    // ConsumerFactory: TradeMatchingEvent 지원
     @Bean
     public ConsumerFactory<String, Object> defaultConsumerFactory() {
         Map<String, Object> props = new HashMap<>();
@@ -128,7 +127,9 @@ public class KafkaConfig {
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
         props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
         props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
-        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, "finpago.common.global.messaging.TradeMatchingEvent");
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.springframework.kafka.support.serializer.ErrorHandlingDeserializer");
+        props.put("spring.deserializer.value.delegate.class", "org.springframework.kafka.support.serializer.JsonDeserializer");
+
 
         return new DefaultKafkaConsumerFactory<>(props);
     }

--- a/user-service/src/main/java/finpago/userservice/user/messaging/consumer/UserConsumer.java
+++ b/user-service/src/main/java/finpago/userservice/user/messaging/consumer/UserConsumer.java
@@ -14,7 +14,8 @@ public class UserConsumer {
 
     private final UserService userService;
 
-    @KafkaListener(topics = "notice-topic", groupId = "user-service-group",containerFactory = "kafkaRetryListenerContainerFactory")
+    @KafkaListener(topics = "notice-topic", groupId = "user-service-group"
+            ,containerFactory = "noticeKafkaRetryListenerContainerFactory")
     public void consumeNotification(NoticeEvent event) {
         log.info("알림 수신 - 사용자 {}: {}", event.getUserId(), event);
         userService.saveNotification(event);


### PR DESCRIPTION

## PR Type
- config 수정

## 해당 PR에 대한 설명
-유저모듈에서 알림, 체결 이벤트 두가지 종류의 이벤트 받을수있도록 consumerfactory분리 하였습니다
- default로 kafkaRetryListenerContainerFactory를 찾아서 <String, Object>로 디폴트 containerfactory를 만들어두었습니다
-> 매수/매도시 유저의 보유주식 업데이트