### PR TITLE
P3-109(#115) [FEAT]: 정산 모듈 전체 비즈니스 로직 수정

### DIFF
--- a/execution-service/src/main/java/finpago/executionservice/execution/messaging/consumer/ExecutionConsumer.java
+++ b/execution-service/src/main/java/finpago/executionservice/execution/messaging/consumer/ExecutionConsumer.java
@@ -18,6 +18,10 @@ public class ExecutionConsumer {
     private final ExecutionService executionService;
     private static final String SELL_TRADE_MATCHING_TOPIC = "sell-trade-matching";
     private static final String BUY_TRADE_MATCHING_TOPIC = "buy-trade-matching";
+
+    private static final String BUY_SETTLEMENT_FAILURE_TOPIC = "buy-settlement-failure-topic";
+    private static final String SELL_SETTLEMENT_FAILURE_TOPIC = "sell-settlement-failure-topic";
+
 //    private final SseEmitterService sseEmitterService;
 
 //    @KafkaListener(topics = "trade-matching-topic", groupId = "execution-service-group",
@@ -41,14 +45,14 @@ public class ExecutionConsumer {
         executionService.processSellTrade(event);
     }
 
-    @KafkaListener(topics = "settlement-failure-topic", groupId = "execution-service-group",
+    @KafkaListener(topics = BUY_SETTLEMENT_FAILURE_TOPIC, groupId = "execution-service-group",
             containerFactory = "buyTradeRetryListenerContainerFactory")
     public void sendFailedBuyTradeToMatching(BuyTradeMatchEvent event) {
         log.warn("매수 체결 실패 - Matching 모듈로 재전송: {}", event);
         executionService.handleBuySettlementFailure(event);
     }
 
-    @KafkaListener(topics = "settlement-failure-topic", groupId = "execution-service-group",
+    @KafkaListener(topics = SELL_SETTLEMENT_FAILURE_TOPIC, groupId = "execution-service-group",
             containerFactory = "sellTradeRetryListenerContainerFactory")
     public void sendFailedSellTradeToMatching(SellTradeMatchEvent event) {
         log.warn("매도 체결 실패 - Matching 모듈로 재전송: {}", event);

--- a/settlement-service/src/main/java/finpago/settlementservice/settlement/config/kafka/KafkaConfig.java
+++ b/settlement-service/src/main/java/finpago/settlementservice/settlement/config/kafka/KafkaConfig.java
@@ -1,5 +1,7 @@
 package finpago.settlementservice.settlement.config.kafka;
 
+import finpago.common.global.messaging.BuyTradeMatchEvent;
+import finpago.common.global.messaging.SellTradeMatchEvent;
 import finpago.common.global.messaging.TradeMatchingEvent;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -23,9 +25,9 @@ public class KafkaConfig {
     private static final String BOOTSTRAP_SERVERS = "localhost:9092";
     private static final String GROUP_ID = "settlement-service-group";
 
-    // TradeMatchingEvent ProducerFactory
+    // BuyTradeMatchEvent ProducerFactory
     @Bean
-    public ProducerFactory<String, TradeMatchingEvent> tradeProducerFactory() {
+    public ProducerFactory<String, BuyTradeMatchEvent> buyTradeProducerFactory() {
         Map<String, Object> props = new HashMap<>();
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
@@ -35,30 +37,67 @@ public class KafkaConfig {
     }
 
     @Bean
-    public KafkaTemplate<String, TradeMatchingEvent> tradeKafkaTemplate() {
-        return new KafkaTemplate<>(tradeProducerFactory());
+    public KafkaTemplate<String, BuyTradeMatchEvent> buyTradeKafkaTemplate() {
+        return new KafkaTemplate<>(buyTradeProducerFactory());
     }
 
-    // ConsumerFactory: TradeMatchingEvent 지원
+    // SellTradeMatchEvent ProducerFactory
     @Bean
-    public ConsumerFactory<String, TradeMatchingEvent> tradeConsumerFactory() {
+    public ProducerFactory<String, SellTradeMatchEvent> sellTradeProducerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        props.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, SellTradeMatchEvent> sellTradeKafkaTemplate() {
+        return new KafkaTemplate<>(sellTradeProducerFactory());
+    }
+
+    // ConsumerFactory: BuyTradeMatchEvent 지원
+    @Bean
+    public ConsumerFactory<String, BuyTradeMatchEvent> buyTradeConsumerFactory() {
         Map<String, Object> props = new HashMap<>();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
         props.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP_ID);
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-        props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
         props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
-        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, "finpago.common.global.messaging.TradeMatchingEvent");
+        props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, "finpago.common.global.messaging.BuyTradeMatchEvent");
 
         return new DefaultKafkaConsumerFactory<>(props);
     }
 
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, BuyTradeMatchEvent> buyTradeKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, BuyTradeMatchEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(buyTradeConsumerFactory());
+        return factory;
+    }
+
+    // ConsumerFactory: SellTradeMatchEvent 지원
+    @Bean
+    public ConsumerFactory<String, SellTradeMatchEvent> sellTradeConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP_ID);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, "finpago.common.global.messaging.SellTradeMatchEvent");
+
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, TradeMatchingEvent> tradeKafkaListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, TradeMatchingEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
-        factory.setConsumerFactory(tradeConsumerFactory());
+    public ConcurrentKafkaListenerContainerFactory<String, SellTradeMatchEvent> sellTradeKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, SellTradeMatchEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(sellTradeConsumerFactory());
         return factory;
     }
 }

--- a/settlement-service/src/main/java/finpago/settlementservice/settlement/config/kafka/KafkaRetryConfig.java
+++ b/settlement-service/src/main/java/finpago/settlementservice/settlement/config/kafka/KafkaRetryConfig.java
@@ -1,5 +1,7 @@
 package finpago.settlementservice.settlement.config.kafka;
 
+import finpago.common.global.messaging.BuyTradeMatchEvent;
+import finpago.common.global.messaging.SellTradeMatchEvent;
 import finpago.common.global.messaging.TradeMatchingEvent;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
@@ -15,30 +17,55 @@ import org.springframework.util.backoff.FixedBackOff;
 @Configuration
 public class KafkaRetryConfig {
 
-    private static final String DLT_TOPIC = "settlement-dlt-topic"; // DLT 토픽
+    private static final String BUY_DLT_TOPIC = "buy-settlement-dlt-topic";
+    private static final String SELL_DLT_TOPIC = "sell-settlement-dlt-topic";
     private static final long RETRY_INTERVAL = 1000L; // 재시도 간격 (1초)
     private static final int RETRY_COUNT = 3; // 최대 재시도 횟수
 
+    // Default Retry Listener Factory (Generic)
     @Bean(name = "kafkaRetryListenerContainerFactory")
-    public ConcurrentKafkaListenerContainerFactory<String, TradeMatchingEvent> kafkaRetryListenerContainerFactory(
-            ConsumerFactory<String, TradeMatchingEvent> consumerFactory,
-            KafkaTemplate<String, TradeMatchingEvent> kafkaTemplate) {
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaRetryListenerContainerFactory(
+            ConsumerFactory<String, Object> consumerFactory,
+            KafkaTemplate<String, Object> kafkaTemplate) {
 
-        ConcurrentKafkaListenerContainerFactory<String, TradeMatchingEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory);
+        factory.setCommonErrorHandler(createErrorHandler(kafkaTemplate));
+        return factory;
+    }
 
-        // 실패한 메시지를 DLT(Dead Letter Topic)으로 이동하는 Recoverer 설정
+    // BuyTradeMatchEvent Retry Listener Factory
+    @Bean(name = "buyTradeRetryListenerContainerFactory")
+    public ConcurrentKafkaListenerContainerFactory<String, BuyTradeMatchEvent> buyTradeRetryListenerContainerFactory(
+            ConsumerFactory<String, BuyTradeMatchEvent> consumerFactory,
+            KafkaTemplate<String, BuyTradeMatchEvent> kafkaTemplate) {
+
+        ConcurrentKafkaListenerContainerFactory<String, BuyTradeMatchEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        factory.setCommonErrorHandler(createErrorHandler(kafkaTemplate));
+        return factory;
+    }
+
+    // SellTradeMatchEvent Retry Listener Factory
+    @Bean(name = "sellTradeRetryListenerContainerFactory")
+    public ConcurrentKafkaListenerContainerFactory<String, SellTradeMatchEvent> sellTradeRetryListenerContainerFactory(
+            ConsumerFactory<String, SellTradeMatchEvent> consumerFactory,
+            KafkaTemplate<String, SellTradeMatchEvent> kafkaTemplate) {
+
+        ConcurrentKafkaListenerContainerFactory<String, SellTradeMatchEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        factory.setCommonErrorHandler(createErrorHandler(kafkaTemplate));
+        return factory;
+    }
+
+    private DefaultErrorHandler createErrorHandler(KafkaTemplate<?, ?> kafkaTemplate) {
         DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
                 kafkaTemplate,
-                (ConsumerRecord<?, ?> record, Exception e) ->
-                        new TopicPartition(DLT_TOPIC, record.partition())
+                (ConsumerRecord<?, ?> record, Exception e) -> {
+                    String topic = record.topic().contains("buy") ? BUY_DLT_TOPIC : SELL_DLT_TOPIC;
+                    return new TopicPartition(topic, record.partition());
+                }
         );
-
-        // 3번 재시도 후 DLT로 이동하는 ErrorHandler
-        DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, new FixedBackOff(RETRY_INTERVAL, RETRY_COUNT));
-
-        factory.setCommonErrorHandler(errorHandler);
-
-        return factory;
+        return new DefaultErrorHandler(recoverer, new FixedBackOff(RETRY_INTERVAL, RETRY_COUNT));
     }
 }

--- a/settlement-service/src/main/java/finpago/settlementservice/settlement/messaging/consumer/SettlementConsumer.java
+++ b/settlement-service/src/main/java/finpago/settlementservice/settlement/messaging/consumer/SettlementConsumer.java
@@ -1,5 +1,7 @@
 package finpago.settlementservice.settlement.messaging.consumer;
 
+import finpago.common.global.messaging.BuyTradeMatchEvent;
+import finpago.common.global.messaging.SellTradeMatchEvent;
 import finpago.common.global.messaging.TradeMatchingEvent;
 import finpago.settlementservice.settlement.service.SettlementService;
 import lombok.RequiredArgsConstructor;
@@ -13,11 +15,20 @@ import org.springframework.stereotype.Component;
 public class SettlementConsumer {
 
     private final SettlementService settlementService;
+    private static final String BUY_TRADE_EXECUTION_TOPIC = "buy-trade-execution-topic";
+    private static final String SELL_TRADE_EXECUTION_TOPIC = "sell-trade-execution-topic";
 
-    @KafkaListener(topics = "trade-execution-topic", groupId = "settlement-service-group",
-            containerFactory = "kafkaRetryListenerContainerFactory")
-    public void handleTradeExecution(TradeMatchingEvent event) {
-        log.info("체결된 주문 정산 모듈에서 수신: {}", event);
-        settlementService.processSettlement(event);
+    @KafkaListener(topics = BUY_TRADE_EXECUTION_TOPIC, groupId = "settlement-service-group",
+            containerFactory = "buyTradeRetryListenerContainerFactory")
+    public void handleTradeExecution(BuyTradeMatchEvent event) {
+        log.info("매수 체결된 주문 정산 모듈에서 수신: {}", event);
+        settlementService.processBuySettlement(event);
+    }
+
+    @KafkaListener(topics = SELL_TRADE_EXECUTION_TOPIC, groupId = "settlement-service-group",
+            containerFactory = "sellTradeRetryListenerContainerFactory")
+    public void handleTradeExecution(SellTradeMatchEvent event) {
+        log.info("매도 체결된 주문 정산 모듈에서 수신: {}", event);
+        settlementService.processSellSettlement(event);
     }
 }

--- a/settlement-service/src/main/java/finpago/settlementservice/settlement/messaging/consumer/SettlementDLTConsumer.java
+++ b/settlement-service/src/main/java/finpago/settlementservice/settlement/messaging/consumer/SettlementDLTConsumer.java
@@ -1,5 +1,7 @@
 package finpago.settlementservice.settlement.messaging.consumer;
 
+import finpago.common.global.messaging.BuyTradeMatchEvent;
+import finpago.common.global.messaging.SellTradeMatchEvent;
 import finpago.common.global.messaging.TradeMatchingEvent;
 import finpago.settlementservice.settlement.messaging.producer.SettlementProducer;
 import lombok.RequiredArgsConstructor;
@@ -14,11 +16,18 @@ public class SettlementDLTConsumer {
 
     private final SettlementProducer settlementProducer;
 
-    private static final String DLT_TOPIC = "settlement-dlt-topic";
+    private static final String BUY_DLT_TOPIC = "buy-settlement-dlt-topic";
+    private static final String SELL_DLT_TOPIC = "sell-settlement-dlt-topic";
 
-    @KafkaListener(topics = DLT_TOPIC, groupId = "settlement-service-group")
-    public void handleFailedSettlement(TradeMatchingEvent event) {
-        log.warn("정산 실패 (DLT) - 체결 모듈로 롤백 요청: {}", event);
-        settlementProducer.sendSettlementFailure(event);
+    @KafkaListener(topics = BUY_DLT_TOPIC, groupId = "settlement-service-group")
+    public void handleFailedBuySettlement(BuyTradeMatchEvent event) {
+        log.warn("매수 정산 실패 (DLT) - 체결 모듈로 롤백 요청: {}", event);
+        settlementProducer.sendBuySettlementFailure(event);
+    }
+
+    @KafkaListener(topics = SELL_DLT_TOPIC, groupId = "settlement-service-group")
+    public void handleFailedSellSettlement(SellTradeMatchEvent event) {
+        log.warn("매도 정산 실패 (DLT) - 체결 모듈로 롤백 요청: {}", event);
+        settlementProducer.sendSellSettlementFailure(event);
     }
 }

--- a/settlement-service/src/main/java/finpago/settlementservice/settlement/messaging/producer/SettlementProducer.java
+++ b/settlement-service/src/main/java/finpago/settlementservice/settlement/messaging/producer/SettlementProducer.java
@@ -1,5 +1,7 @@
 package finpago.settlementservice.settlement.messaging.producer;
 
+import finpago.common.global.messaging.BuyTradeMatchEvent;
+import finpago.common.global.messaging.SellTradeMatchEvent;
 import finpago.common.global.messaging.TradeMatchingEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,17 +13,31 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class SettlementProducer {
 
-    private final KafkaTemplate<String, TradeMatchingEvent> kafkaTemplate;
-    private static final String SETTLEMENT_TOPIC = "settlement-topic";
-    private static final String SETTLEMENT_FAILURE_TOPIC = "settlement-failure-topic";
+    private final KafkaTemplate<String, BuyTradeMatchEvent> buyTradeKafkaTemplate;
+    private final KafkaTemplate<String, SellTradeMatchEvent> sellTradeKafkaTemplate;
 
-    public void sendSettlementSuccess(TradeMatchingEvent event) {
-        kafkaTemplate.send(SETTLEMENT_TOPIC, event);
-        log.info("정산 완료 이벤트 발행: {}", event);
+    private static final String BUY_SETTLEMENT_TOPIC = "buy-settlement-topic";
+    private static final String SELL_SETTLEMENT_TOPIC = "sell-settlement-topic";
+    private static final String BUY_SETTLEMENT_FAILURE_TOPIC = "buy-settlement-failure-topic";
+    private static final String SELL_SETTLEMENT_FAILURE_TOPIC = "sell-settlement-failure-topic";
+
+    public void sendBuySettlementSuccess(BuyTradeMatchEvent event) {
+        buyTradeKafkaTemplate.send(BUY_SETTLEMENT_TOPIC, event);
+        log.info("매수 정산 완료 이벤트 발행: {}", event);
     }
 
-    public void sendSettlementFailure(TradeMatchingEvent event) {
-        kafkaTemplate.send(SETTLEMENT_FAILURE_TOPIC, event);
-        log.warn("정산 실패 이벤트 발행: {}", event);
+    public void sendSellSettlementSuccess(SellTradeMatchEvent event) {
+        sellTradeKafkaTemplate.send(SELL_SETTLEMENT_TOPIC, event);
+        log.info("매도 정산 완료 이벤트 발행: {}", event);
+    }
+
+    public void sendBuySettlementFailure(BuyTradeMatchEvent event) {
+        buyTradeKafkaTemplate.send(BUY_SETTLEMENT_FAILURE_TOPIC, event);
+        log.warn("매수 정산 실패 이벤트 발행: {}", event);
+    }
+
+    public void sendSellSettlementFailure(SellTradeMatchEvent event) {
+        sellTradeKafkaTemplate.send(SELL_SETTLEMENT_FAILURE_TOPIC, event);
+        log.warn("매도 정산 실패 이벤트 발행: {}", event);
     }
 }

--- a/settlement-service/src/main/java/finpago/settlementservice/settlement/service/SettlementService.java
+++ b/settlement-service/src/main/java/finpago/settlementservice/settlement/service/SettlementService.java
@@ -2,6 +2,8 @@ package finpago.settlementservice.settlement.service;
 
 import finpago.common.global.exception.error.InsufficientBalanceException;
 import finpago.common.global.exception.error.InsufficientStockException;
+import finpago.common.global.messaging.BuyTradeMatchEvent;
+import finpago.common.global.messaging.SellTradeMatchEvent;
 import finpago.common.global.messaging.TradeMatchingEvent;
 import finpago.settlementservice.settlement.messaging.producer.SettlementProducer;
 import lombok.RequiredArgsConstructor;
@@ -24,45 +26,50 @@ public class SettlementService {
     private static final float DEFAULT_EXCHANGE_RATE = 1.0f; // 기본 환율 (1.0)
     private static final long EXPIRATION_DAYS = 30; // Redis 데이터 보관 기간 (30일)
 
-    @Transactional
-    public void processSettlement(TradeMatchingEvent event) {
-        validateBuyerBalance(event);
-        validateSellerStocks(event);
 
-        // Redis에서 환율 조회 (없을 경우 기본값 적용)
+    @Transactional
+    public void processBuySettlement(BuyTradeMatchEvent event) {
+        validateBuyerBalance(event);
+
         Float exchangeRate = getExchangeRate(event.getStockTicker());
         event.setExchangeRate(exchangeRate);
 
-        //매수자
         updateBatchBalance(event.getBuyerUserId(), -event.getTradePrice() * event.getTradeQuantity());
-        updateBalance(event.getBuyerUserId(), -event.getTradePrice() * event.getTradeQuantity());// 실제 예수금 감소
-        updateHoldings(event.getBuyerUserId(), event.getStockTicker(), event.getTradeQuantity()); // 보유 주식 증가 (배치)
-
-
-        // 매도자
-        updateBatchBalance(event.getSellerUserId(), event.getTradePrice() * event.getTradeQuantity());//배치용증가
-//        updateBalance(event.getSellerUserId(), event.getTradePrice() * event.getTradeQuantity()); //사용자에게 보여지는 출금가능 예수금은 그대로
-        updateHoldings(event.getSellerUserId(), event.getStockTicker(), -event.getTradeQuantity()); // 보유 주식 감소 (배치)
-
-        // 환차손익 저장 (tradePrice 추가)
+        updateBalance(event.getBuyerUserId(), -event.getTradePrice() * event.getTradeQuantity());
+        updateHoldings(event.getBuyerUserId(), event.getStockTicker(), event.getTradeQuantity());
         updateStockForFxTracking(event.getBuyerUserId(), event.getStockTicker(), event.getTradeQuantity(), exchangeRate, event.getTradePrice());
+
+        settlementProducer.sendBuySettlementSuccess(event);
+        log.info("매수 정산 완료: {}", event);
+    }
+
+
+    @Transactional
+    public void processSellSettlement(SellTradeMatchEvent event) {
+        validateSellerStocks(event);
+
+        Float exchangeRate = getExchangeRate(event.getStockTicker());
+        event.setExchangeRate(exchangeRate);
+
+        updateBatchBalance(event.getSellerUserId(), event.getTradePrice() * event.getTradeQuantity());
+        updateHoldings(event.getSellerUserId(), event.getStockTicker(), -event.getTradeQuantity());
         updateStockForFxTracking(event.getSellerUserId(), event.getStockTicker(), -event.getTradeQuantity(), exchangeRate, event.getTradePrice());
 
-        settlementProducer.sendSettlementSuccess(event);
-        log.info("정산 완료: {}", event);
+        settlementProducer.sendSellSettlementSuccess(event);
+        log.info("매도 정산 완료: {}", event);
     }
 
     /**
      * 매수자의 예수금 검증
      */
-    private void validateBuyerBalance(TradeMatchingEvent event) {
+    private void validateBuyerBalance(BuyTradeMatchEvent event) {
         Long buyerAvailableBalance = getCachedAvailableBalance(event.getBuyerUserId());
         Long requiredAmount = event.getTradePrice() * event.getTradeQuantity();
 
         if (buyerAvailableBalance < requiredAmount) {
             log.error("예수금 부족 - 매수자 ID: {}, 필요 금액: {}, 보유 금액: {}",
                     event.getBuyerUserId(), requiredAmount, buyerAvailableBalance);
-            settlementProducer.sendSettlementFailure(event);
+            settlementProducer.sendBuySettlementFailure(event);
             throw new InsufficientBalanceException("예수금 부족으로 정산 실패");
         }
     }
@@ -70,13 +77,13 @@ public class SettlementService {
     /**
      * 매도자의 보유 주식 검증
      */
-    private void validateSellerStocks(TradeMatchingEvent event) {
+    private void validateSellerStocks(SellTradeMatchEvent event) {
         Long sellerAvailableStocks = getCachedAvailableStocks(event.getSellerUserId(), event.getStockTicker());
 
         if (sellerAvailableStocks < event.getTradeQuantity()) {
             log.error("보유 주식 부족 - 매도자 ID: {}, 필요 주식: {}, 보유 주식: {}",
                     event.getSellerUserId(), event.getTradeQuantity(), sellerAvailableStocks);
-            settlementProducer.sendSettlementFailure(event);
+            settlementProducer.sendSellSettlementFailure(event);
             throw new InsufficientStockException("보유 주식 부족으로 정산 실패");
         }
     }


### PR DESCRIPTION
## PR Type
-정산 모듈 전체 비즈니스 로직 수정 

## 해당 PR에 대한 설명

### 정산 로직 개선
- processBuySettlement 및 processSellSettlement를 분리하여 매수/매도 정산 처리를 각각 수행하도록 수정
- 매수자의 예수금 검증(validateBuyerBalance)과 매도자의 주식 보유량 검증(validateSellerStocks)을 각각 처리하도록 변경
- 정산 실패 시 개별적인 롤백 처리가 가능하도록 sendBuySettlementFailure, sendSellSettlementFailure 추가

### Kafka 설정 수정
1. Producer
- BuyTradeMatchEvent, SellTradeMatchEvent를 각각 처리하는 buyTradeKafkaTemplate, sellTradeKafkaTemplate 추가

2. Consumer
- BuyTradeMatchEvent, SellTradeMatchEvent 전용 ConsumerFactory 및 Listener 추가

### 리트라이 설정 (KafkaRetryConfig)
- 기본(Generic) 리트라이 처리 추가 (kafkaRetryListenerContainerFactory)
- BuyTradeMatchEvent, SellTradeMatchEvent 전용 리트라이 리스너 추가 (buyTradeRetryListenerContainerFactory, sellTradeRetryListenerContainerFactory)
- DLT(Dead Letter Topic) 로직 개선하여 매수/매도 실패 메시지를 각각 BUY_DLT_TOPIC, SELL_DLT_TOPIC으로 이동하도록 설정