### PR TITLE
P3-109(#115) [FEAT]: 알림 모듈 전체 비즈니스 로직 수정

### DIFF
--- a/notification-service/src/main/java/finpago/notificationservice/notification/config/kafka/KafkaConfig.java
+++ b/notification-service/src/main/java/finpago/notificationservice/notification/config/kafka/KafkaConfig.java
@@ -1,5 +1,7 @@
 package finpago.notificationservice.notification.config.kafka;
 
+import finpago.common.global.messaging.BuyTradeMatchEvent;
+import finpago.common.global.messaging.SellTradeMatchEvent;
 import finpago.common.global.messaging.TradeMatchingEvent;
 import finpago.common.global.messaging.NoticeEvent;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -24,9 +26,9 @@ public class KafkaConfig {
     private static final String BOOTSTRAP_SERVERS = "localhost:9092";
     private static final String GROUP_ID = "notification-service-group";
 
-    // ProducerFactory (TradeMatchingEvent)
+    // BuyTradeMatchEvent ProducerFactory
     @Bean
-    public ProducerFactory<String, TradeMatchingEvent> tradeProducerFactory() {
+    public ProducerFactory<String, BuyTradeMatchEvent> buyTradeProducerFactory() {
         Map<String, Object> props = new HashMap<>();
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
@@ -36,8 +38,24 @@ public class KafkaConfig {
     }
 
     @Bean
-    public KafkaTemplate<String, TradeMatchingEvent> tradeKafkaTemplate() {
-        return new KafkaTemplate<>(tradeProducerFactory());
+    public KafkaTemplate<String, BuyTradeMatchEvent> buyTradeKafkaTemplate() {
+        return new KafkaTemplate<>(buyTradeProducerFactory());
+    }
+
+    // SellTradeMatchEvent ProducerFactory
+    @Bean
+    public ProducerFactory<String, SellTradeMatchEvent> sellTradeProducerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        props.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, SellTradeMatchEvent> sellTradeKafkaTemplate() {
+        return new KafkaTemplate<>(sellTradeProducerFactory());
     }
 
     // ProducerFactory (NoticeEvent)
@@ -56,8 +74,9 @@ public class KafkaConfig {
         return new KafkaTemplate<>(noticeProducerFactory());
     }
 
+    // ConsumerFactory: BuyTradeMatchEvent 지원
     @Bean
-    public ConsumerFactory<String, TradeMatchingEvent> tradeConsumerFactory() {
+    public ConsumerFactory<String, BuyTradeMatchEvent> buyTradeConsumerFactory() {
         Map<String, Object> props = new HashMap<>();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
         props.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP_ID);
@@ -65,22 +84,37 @@ public class KafkaConfig {
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
         props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
         props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
-        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, "finpago.common.global.messaging.TradeMatchingEvent");
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, "finpago.common.global.messaging.BuyTradeMatchEvent");
 
-        System.out.println("바밥밥 "+props.get(JsonDeserializer.VALUE_DEFAULT_TYPE));
         return new DefaultKafkaConsumerFactory<>(props);
-
-//        return new DefaultKafkaConsumerFactory<>(
-//                props,
-//                new StringDeserializer(),
-//                new JsonDeserializer<>(TradeMatchingEvent.class, false)
-//        );
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, TradeMatchingEvent> tradeKafkaListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, TradeMatchingEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
-        factory.setConsumerFactory(tradeConsumerFactory());
+    public ConcurrentKafkaListenerContainerFactory<String, BuyTradeMatchEvent> buyTradeKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, BuyTradeMatchEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(buyTradeConsumerFactory());
+        return factory;
+    }
+
+    // ConsumerFactory: SellTradeMatchEvent 지원
+    @Bean
+    public ConsumerFactory<String, SellTradeMatchEvent> sellTradeConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP_ID);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, "finpago.common.global.messaging.SellTradeMatchEvent");
+
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, SellTradeMatchEvent> sellTradeKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, SellTradeMatchEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(sellTradeConsumerFactory());
         return factory;
     }
 }

--- a/notification-service/src/main/java/finpago/notificationservice/notification/config/kafka/KafkaRetryConfig.java
+++ b/notification-service/src/main/java/finpago/notificationservice/notification/config/kafka/KafkaRetryConfig.java
@@ -1,5 +1,7 @@
 package finpago.notificationservice.notification.config.kafka;
 
+import finpago.common.global.messaging.BuyTradeMatchEvent;
+import finpago.common.global.messaging.SellTradeMatchEvent;
 import finpago.common.global.messaging.TradeMatchingEvent;
 import finpago.common.global.messaging.NoticeEvent;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -16,31 +18,55 @@ import org.springframework.util.backoff.FixedBackOff;
 @Configuration
 public class KafkaRetryConfig {
 
-    private static final String TRADE_DLT_TOPIC = "trade-settlement-dlt-topic"; // TradeMatchingEvent DLT
-    private static final String NOTICE_DLT_TOPIC = "notice-dlt-topic"; // NoticeEvent DLT
+    private static final String BUY_DLT_TOPIC = "buy-settlement-dlt-topic";
+    private static final String SELL_DLT_TOPIC = "sell-settlement-dlt-topic";// TradeMatchingEvent DLT// NoticeEvent DLT
     private static final long RETRY_INTERVAL = 1000L; // 재시도 간격 (1초)
     private static final int RETRY_COUNT = 3; // 최대 재시도 횟수
 
+    // Default Retry Listener Factory (Generic)
     @Bean(name = "kafkaRetryListenerContainerFactory")
-    public ConcurrentKafkaListenerContainerFactory<String, TradeMatchingEvent> kafkaRetryListenerContainerFactory(
-            ConsumerFactory<String, TradeMatchingEvent> consumerFactory,
-            KafkaTemplate<String, TradeMatchingEvent> kafkaTemplate) {
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaRetryListenerContainerFactory(
+            ConsumerFactory<String, Object> consumerFactory,
+            KafkaTemplate<String, Object> kafkaTemplate) {
 
-        ConcurrentKafkaListenerContainerFactory<String, TradeMatchingEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory);
+        factory.setCommonErrorHandler(createErrorHandler(kafkaTemplate));
+        return factory;
+    }
 
-        // 실패한 메시지를 DLT(Dead Letter Topic)으로 이동하는 Recoverer 설정
+    // BuyTradeMatchEvent Retry Listener Factory
+    @Bean(name = "buyTradeRetryListenerContainerFactory")
+    public ConcurrentKafkaListenerContainerFactory<String, BuyTradeMatchEvent> buyTradeRetryListenerContainerFactory(
+            ConsumerFactory<String, BuyTradeMatchEvent> consumerFactory,
+            KafkaTemplate<String, BuyTradeMatchEvent> kafkaTemplate) {
+
+        ConcurrentKafkaListenerContainerFactory<String, BuyTradeMatchEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        factory.setCommonErrorHandler(createErrorHandler(kafkaTemplate));
+        return factory;
+    }
+
+    // SellTradeMatchEvent Retry Listener Factory
+    @Bean(name = "sellTradeRetryListenerContainerFactory")
+    public ConcurrentKafkaListenerContainerFactory<String, SellTradeMatchEvent> sellTradeRetryListenerContainerFactory(
+            ConsumerFactory<String, SellTradeMatchEvent> consumerFactory,
+            KafkaTemplate<String, SellTradeMatchEvent> kafkaTemplate) {
+
+        ConcurrentKafkaListenerContainerFactory<String, SellTradeMatchEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        factory.setCommonErrorHandler(createErrorHandler(kafkaTemplate));
+        return factory;
+    }
+
+    private DefaultErrorHandler createErrorHandler(KafkaTemplate<?, ?> kafkaTemplate) {
         DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
                 kafkaTemplate,
-                (ConsumerRecord<?, ?> record, Exception e) ->
-                        new TopicPartition(TRADE_DLT_TOPIC, record.partition())
+                (ConsumerRecord<?, ?> record, Exception e) -> {
+                    String topic = record.topic().contains("buy") ? BUY_DLT_TOPIC : SELL_DLT_TOPIC;
+                    return new TopicPartition(topic, record.partition());
+                }
         );
-
-        // 3번 재시도 후 DLT로 이동하는 ErrorHandler
-        DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, new FixedBackOff(RETRY_INTERVAL, RETRY_COUNT));
-
-        factory.setCommonErrorHandler(errorHandler);
-
-        return factory;
+        return new DefaultErrorHandler(recoverer, new FixedBackOff(RETRY_INTERVAL, RETRY_COUNT));
     }
 }

--- a/notification-service/src/main/java/finpago/notificationservice/notification/messaging/consumer/NotificationConsumer.java
+++ b/notification-service/src/main/java/finpago/notificationservice/notification/messaging/consumer/NotificationConsumer.java
@@ -1,6 +1,8 @@
 package finpago.notificationservice.notification.messaging.consumer;
 
 
+import finpago.common.global.messaging.BuyTradeMatchEvent;
+import finpago.common.global.messaging.SellTradeMatchEvent;
 import finpago.common.global.messaging.TradeMatchingEvent;
 import finpago.notificationservice.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
@@ -14,17 +16,20 @@ import org.springframework.stereotype.Component;
 public class NotificationConsumer {
 
     private final NotificationService notificationService;
-    private static final String SETTLEMENT_TOPIC = "settlement-topic";
+    private static final String BUY_SETTLEMENT_TOPIC = "buy-settlement-topic";
+    private static final String SELL_SETTLEMENT_TOPIC = "sell-settlement-topic";
 
-    @KafkaListener(topics = SETTLEMENT_TOPIC, groupId = "notification-service-group",
-            containerFactory = "kafkaRetryListenerContainerFactory")
-    public void handleTradeSettlement(TradeMatchingEvent event) {
-        log.info("정산 완료 이벤트 수신: {}", event);
-
-        // 매수자 알림 생성
+    @KafkaListener(topics = BUY_SETTLEMENT_TOPIC, groupId = "notification-service-group",
+            containerFactory = "buyTradeRetryListenerContainerFactory")
+    public void handleBuyTradeSettlement(BuyTradeMatchEvent event) {
+        log.info("매수 정산 완료 이벤트 수신: {}", event);
         notificationService.sendBuyOrderNotification(event);
+    }
 
-        // 매도자 알림 생성
+    @KafkaListener(topics = SELL_SETTLEMENT_TOPIC, groupId = "notification-service-group",
+            containerFactory = "sellTradeRetryListenerContainerFactory")
+    public void handleSellTradeSettlement(SellTradeMatchEvent event) {
+        log.info("매도 정산 완료 이벤트 수신: {}", event);
         notificationService.sendSellOrderNotification(event);
     }
 }

--- a/notification-service/src/main/java/finpago/notificationservice/notification/messaging/consumer/NotificationDLTConsumer.java
+++ b/notification-service/src/main/java/finpago/notificationservice/notification/messaging/consumer/NotificationDLTConsumer.java
@@ -1,0 +1,27 @@
+package finpago.notificationservice.notification.messaging.consumer;
+
+import finpago.common.global.messaging.BuyTradeMatchEvent;
+import finpago.common.global.messaging.SellTradeMatchEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationDLTConsumer {
+
+    private static final String BUY_DLT_TOPIC = "buy-notification-dlt-topic";
+    private static final String SELL_DLT_TOPIC = "sell-notification-dlt-topic";
+
+    @KafkaListener(topics = BUY_DLT_TOPIC, groupId = "notification-service-group")
+    public void handleFailedBuyTradeNotification(BuyTradeMatchEvent event) {
+        log.warn("매수 정산 알림 실패 (DLT) - 재시도 또는 로그 저장: {}", event);
+    }
+
+    @KafkaListener(topics = SELL_DLT_TOPIC, groupId = "notification-service-group")
+    public void handleFailedSellTradeNotification(SellTradeMatchEvent event) {
+        log.warn("매도 정산 알림 실패 (DLT) - 재시도 또는 로그 저장: {}", event);
+    }
+}

--- a/notification-service/src/main/java/finpago/notificationservice/notification/service/NotificationService.java
+++ b/notification-service/src/main/java/finpago/notificationservice/notification/service/NotificationService.java
@@ -1,5 +1,7 @@
 package finpago.notificationservice.notification.service;
 
+import finpago.common.global.messaging.BuyTradeMatchEvent;
+import finpago.common.global.messaging.SellTradeMatchEvent;
 import finpago.common.global.messaging.TradeMatchingEvent;
 import finpago.common.global.messaging.NoticeEvent;
 import finpago.notificationservice.notification.client.UserClient;
@@ -19,7 +21,7 @@ public class NotificationService {
     /**
      * 매수자 알림 생성 및 발송
      */
-    public void sendBuyOrderNotification(TradeMatchingEvent event) {
+    public void sendBuyOrderNotification(BuyTradeMatchEvent event) {
         boolean isNotificationEnabled = userClient.getNotificationSetting(event.getBuyerUserId());
 
         if (!isNotificationEnabled) {
@@ -31,7 +33,7 @@ public class NotificationService {
                 event.getBuyerUserId(),
                 "[해외주식 매수 주문 체결]",
                 event.getStockTicker(),
-                event.getBuyerOrderQuentity(),
+                event.getBuyerOrderQuantity(),
                 event.getTradeQuantity(),
                 event.getTradePrice()
         );
@@ -43,7 +45,7 @@ public class NotificationService {
     /**
      * 매도자 알림 생성 및 발송
      */
-    public void sendSellOrderNotification(TradeMatchingEvent event) {
+    public void sendSellOrderNotification(SellTradeMatchEvent event) {
         boolean isNotificationEnabled = userClient.getNotificationSetting(event.getSellerUserId());
 
         if (!isNotificationEnabled) {
@@ -55,7 +57,7 @@ public class NotificationService {
                 event.getSellerUserId(),
                 "[해외주식 매도 주문 체결]",
                 event.getStockTicker(),
-                event.getSellerOrderQuentity(),
+                event.getSellerOrderQuantity(),
                 event.getTradeQuantity(),
                 event.getTradePrice()
         );


### PR DESCRIPTION
## PR Type
-알림 모듈 전체 비즈니스 로직 수정


## 해당 PR에 대한 설명

### 알림 처리 로직 개선
- BuyTradeMatchEvent와 SellTradeMatchEvent를 개별적으로 처리하도록 수정
- 매수(handleBuyTradeSettlement) 및 매도(handleSellTradeSettlement) 정산 알림을 각각 관리

### DLT(Dead Letter Topic) 기반 실패 처리 추가
- handleFailedBuyTradeNotification: BUY_DLT_TOPIC에서 매수 알림 실패 처리
- handleFailedSellTradeNotification: SELL_DLT_TOPIC에서 매도 알림 실패 처리
