### PR TITLE
P3-108(#113) [FEAT]: 주문목록 반환하는 API

### DIFF
--- a/execution-service/src/main/java/finpago/executionservice/execution/controller/TradeController.java
+++ b/execution-service/src/main/java/finpago/executionservice/execution/controller/TradeController.java
@@ -56,6 +56,24 @@ public class TradeController {
         Long userId = Long.parseLong(authentication.getName());
         List<TradeDto> trades = tradeViewService.getFailedTrades(userId);
 
-        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "실패한 체결 내역 조회 성공", trades));
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "미체결 내역 조회 성공", trades));
+    }
+
+    /**
+     * 유저의 전체 체결 내역 조회 API (SUCCESS, PENDING, FAILED 포함)
+     */
+    @GetMapping("/trades/all")
+    public ResponseEntity<ApiResponse<List<TradeDto>>> getAllTrades() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getPrincipal().equals("anonymousUser")) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.fail(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자"));
+        }
+
+        Long userId = Long.parseLong(authentication.getName());
+        List<TradeDto> trades = tradeViewService.getAllTrades(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "전체 체결 내역 조회 성공", trades));
     }
 }

--- a/execution-service/src/main/java/finpago/executionservice/execution/dto/TradeDto.java
+++ b/execution-service/src/main/java/finpago/executionservice/execution/dto/TradeDto.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class TradeDto {
     private String stockTicker;
+    private String executionType; //매매구분(현금매도,현금매수)
     private Long offerPrice;
     private Long orderQuantity;
     private Long tradePrice;

--- a/execution-service/src/main/java/finpago/executionservice/execution/service/ExecutionService.java
+++ b/execution-service/src/main/java/finpago/executionservice/execution/service/ExecutionService.java
@@ -44,7 +44,7 @@ public class ExecutionService {
     @Transactional
     public void processBuyTrade(BuyTradeMatchEvent event) {
         validateBuyerBalance(event);
-
+        System.out.println("체결 정보는용: "+event);
         TradeStatus status = (event.getUnfilledQuantity() > 0) ? TradeStatus.PENDING : TradeStatus.SUCCESS;
 
         BuyTrade trade = BuyTrade.builder()

--- a/execution-service/src/main/java/finpago/executionservice/execution/service/TradeViewService.java
+++ b/execution-service/src/main/java/finpago/executionservice/execution/service/TradeViewService.java
@@ -12,8 +12,9 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-//체결내역 조회 비즈니스 로직
+// 체결내역 조회 비즈니스 로직
 @Service
 @RequiredArgsConstructor
 public class TradeViewService {
@@ -33,8 +34,10 @@ public class TradeViewService {
                 .map(this::convertToTradeDto)
                 .collect(Collectors.toList());
 
-        buyTrades.addAll(sellTrades);
-        return buyTrades;
+        // 최신순 정렬
+        return Stream.concat(buyTrades.stream(), sellTrades.stream())
+                .sorted((t1, t2) -> t2.getTradeDate().compareTo(t1.getTradeDate()))
+                .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
@@ -49,13 +52,35 @@ public class TradeViewService {
                 .map(this::convertToTradeDto)
                 .collect(Collectors.toList());
 
-        buyTrades.addAll(sellTrades);
-        return buyTrades;
+        // 최신순 정렬
+        return Stream.concat(buyTrades.stream(), sellTrades.stream())
+                .sorted((t1, t2) -> t2.getTradeDate().compareTo(t1.getTradeDate()))
+                .collect(Collectors.toList());
+    }
+
+    // 전체 체결 내역 조회 (SUCCESS, PENDING, FAILED)
+    @Transactional(readOnly = true)
+    public List<TradeDto> getAllTrades(Long userId) {
+        List<TradeDto> buyTrades = buyTradeRepository.findByBuyerUserId(userId)
+                .stream()
+                .map(this::convertToTradeDto)
+                .collect(Collectors.toList());
+
+        List<TradeDto> sellTrades = sellTradeRepository.findBySellerUserId(userId)
+                .stream()
+                .map(this::convertToTradeDto)
+                .collect(Collectors.toList());
+
+        // 최신순 정렬
+        return Stream.concat(buyTrades.stream(), sellTrades.stream())
+                .sorted((t1, t2) -> t2.getTradeDate().compareTo(t1.getTradeDate()))
+                .collect(Collectors.toList());
     }
 
     private TradeDto convertToTradeDto(BuyTrade trade) {
         return new TradeDto(
                 trade.getTradeTicker(),
+                "현금매수", // BUY 거래
                 trade.getBuyerOfferPrice(),
                 trade.getBuyerOrderQuantity(),
                 trade.getTradePrice(),
@@ -70,6 +95,7 @@ public class TradeViewService {
     private TradeDto convertToTradeDto(SellTrade trade) {
         return new TradeDto(
                 trade.getTradeTicker(),
+                "현금매도", // SELL 거래
                 trade.getSellerOfferPrice(),
                 trade.getSellerOrderQuantity(),
                 trade.getTradePrice(),

--- a/user-service/src/main/java/finpago/userservice/holdings/controller/HoldingController.java
+++ b/user-service/src/main/java/finpago/userservice/holdings/controller/HoldingController.java
@@ -44,15 +44,20 @@ public class HoldingController {
     }
 
     /**
-     * 사용자의 보유 주식 정보 조회
+     * 사용자의 보유 주식 정보 조회 (정렬 조건 추가)
+     * @param sortBy 정렬 조건 (profit: 수익률순, evaluation: 평가금액순, buyAmount: 매수금액순)
      * @return List<UserHoldingsDto> (보유 주식 정보 리스트)
      */
     @GetMapping
-    public ResponseEntity<ApiResponse<List<UserHoldingsDto>>> getUserHoldings() {
+    public ResponseEntity<ApiResponse<List<UserHoldingsDto>>> getUserHoldings(
+            @RequestParam(required = false, defaultValue = "evaluation") String sortBy) {
+
         Long userId = getUserIdFromAuth();
-        List<UserHoldingsDto> userHoldings = holdingService.getUserHoldings(userId);
+        List<UserHoldingsDto> userHoldings = holdingService.getUserHoldings(userId, sortBy);
+
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "보유 주식 정보 조회 성공", userHoldings));
     }
+
 
     /**
      * 인증된 사용자 ID 가져오기

--- a/user-service/src/main/java/finpago/userservice/holdings/service/HoldingService.java
+++ b/user-service/src/main/java/finpago/userservice/holdings/service/HoldingService.java
@@ -12,6 +12,7 @@ import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -46,18 +47,18 @@ public class HoldingService {
         return value != null ? Long.parseLong(value) : DEFAULT_STOCKS;
     }
 
-
     /**
      * 사용자의 보유 주식 정보 조회
      * @param userId 사용자 ID
+     * @param sortBy 정렬 기준 (profit: 수익률순, evaluation: 평가금액순, buyAmount: 매수금액순)
      * @return List<UserHoldingsDto> (보유 주식 정보 리스트)
      */
-    public List<UserHoldingsDto> getUserHoldings(Long userId) {
+    public List<UserHoldingsDto> getUserHoldings(Long userId, String sortBy) {
         // 사용자의 보유 종목 목록 가져오기
         List<Holdings> userHoldings = holdingsRepository.findByUserId(userId);
 
         // 각 보유 종목에 대해 DTO 변환
-        return userHoldings.stream()
+        List<UserHoldingsDto> holdingsDtoList = userHoldings.stream()
                 .map(holding -> {
                     String stockTicker = holding.getStockTicker();
 
@@ -73,14 +74,14 @@ public class HoldingService {
                     // 평가 금액(KRW) = 보유 수량 * 현재가
                     double evaluationAmount = holdingQuantity * currentPrice;
 
-                    //매수금액
-                    double buyAmount=holding.getHoldingPrice() * holdingQuantity;
+                    // 매수 금액
+                    double buyAmount = holding.getHoldingPrice() * holdingQuantity;
 
-                    // 손익등락(KRW) 계산(평가금액-매수금액)
-                    double profitChange = evaluationAmount-buyAmount;
+                    // 손익등락(KRW) 계산(평가금액 - 매수금액)
+                    double profitChange = evaluationAmount - buyAmount;
 
-                    // 수익률(%) 계산
-                    double returnRate = profitChange/buyAmount *100;
+                    // 수익률(%) 계산 (매수 금액이 0이 아닐 때만 계산)
+                    double returnRate = (buyAmount > 0) ? (profitChange / buyAmount) * 100 : 0.0;
 
                     return UserHoldingsDto.builder()
                             .stockTicker(stockTicker)
@@ -93,6 +94,34 @@ public class HoldingService {
                             .returnRate(returnRate)
                             .build();
                 }).collect(Collectors.toList());
+
+        // 정렬 로직 적용
+        return sortHoldings(holdingsDtoList, sortBy);
+    }
+
+    /**
+     * 보유 주식 리스트 정렬
+     * @param holdingsDtoList 보유 주식 리스트
+     * @param sortBy 정렬 기준 (profit: 수익률순, evaluation: 평가금액순, buyAmount: 매수금액순)
+     * @return 정렬된 보유 주식 리스트
+     */
+    private List<UserHoldingsDto> sortHoldings(List<UserHoldingsDto> holdingsDtoList, String sortBy) {
+        switch (sortBy) {
+            case "profit":
+                return holdingsDtoList.stream()
+                        .sorted(Comparator.comparingDouble(UserHoldingsDto::getReturnRate).reversed()) // 수익률 내림차순
+                        .collect(Collectors.toList());
+            case "evaluation":
+                return holdingsDtoList.stream()
+                        .sorted(Comparator.comparingDouble(UserHoldingsDto::getEvaluationAmount).reversed()) // 평가 금액 내림차순
+                        .collect(Collectors.toList());
+            case "buyAmount":
+                return holdingsDtoList.stream()
+                        .sorted(Comparator.comparingDouble(UserHoldingsDto::getBuyAmount).reversed()) // 매수 금액 내림차순
+                        .collect(Collectors.toList());
+            default:
+                return holdingsDtoList; // 기본적으로 정렬하지 않고 반환
+        }
     }
 
     //평단가,환율,수량 업데이트 (없다면 holding객체 생성)


### PR DESCRIPTION
## PR Type
- 기능추가

## 해당 PR에 대한 설명
- 주문목록 조회 api개발 ( 체결,부분체결 / 미체결 ) 분리

- 사용자의 보유 주식 조회 시 정렬 옵션 (`sortBy`) 추가
  - `profit` → 수익률(%) 내림차순 정렬
  - `evaluation` → 평가 금액 내림차순 정렬 (기본값)
  - `buyAmount` → 매수 금액 내림차순 정렬
- 컨트롤러, 서비스 로직 수정 및 정렬 메서드(`sortHoldings`) 추가