### PR TITLE
P3-115(#126) [FEAT] 트레이딩 - 실시간 환율 조회 API

### DIFF
--- a/data-service/src/main/java/finpago/dataservice/exchangeRate/ExchangeRateScheduler.java
+++ b/data-service/src/main/java/finpago/dataservice/exchangeRate/ExchangeRateScheduler.java
@@ -23,11 +23,6 @@ public class ExchangeRateScheduler {
                 "NOW", "INTC", "PLTR", "ASML", "V", "XOM", "KO", "WMT", "LIN", "MS"
         };
         // 나중에 동적으로 변경 가능
-        Double rate = exchangeRateService.getExchangeRate(tickers);
-        if (rate != null) {
-            System.out.println("[ " + LocalDateTime.now() + " ] 환율 업데이트: 1 USD = " + rate + " KRW");
-        } else {
-            System.out.println("환율 데이터를 가져오지 못했습니다.");
-        }
+        exchangeRateService.getExchangeRate(tickers);
     }
 }

--- a/data-service/src/main/java/finpago/dataservice/exchangeRate/ExchangeRateService.java
+++ b/data-service/src/main/java/finpago/dataservice/exchangeRate/ExchangeRateService.java
@@ -2,43 +2,101 @@ package finpago.dataservice.exchangeRate;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.data.redis.core.RedisTemplate;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
 @Service
+@RequiredArgsConstructor
 public class ExchangeRateService {
 
     private final RestTemplate restTemplate = new RestTemplate();
     private final RedisTemplate<String, String> redisTemplate;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    public ExchangeRateService(RedisTemplate<String, String> redisTemplate) {
-        this.redisTemplate = redisTemplate;
+
+    // 기본 환율 배율 값 (조회 실패 시 사용) - 1000원 대비 몇 배인지
+    private static final Map<String, Double> DEFAULT_EXCHANGE_RATES = new HashMap<>();
+
+    static {
+        DEFAULT_EXCHANGE_RATES.put("AAPL", 1.32);  // 미국 (USD → KRW)
+        DEFAULT_EXCHANGE_RATES.put("MSFT", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("NVDA", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("GOOGL", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("AMZN", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("META", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("TSLA", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("LLY", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("AVGO", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("JPM", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("IBM", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("MA", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("ORCL", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("COST", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("UNH", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("NFLX", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("AMD", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("TSM", 0.042);  // 대만 (TWD → KRW)
+        DEFAULT_EXCHANGE_RATES.put("ADBE", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("CRM", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("NOW", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("INTC", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("PLTR", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("ASML", 1.44);  // 네덜란드 (EUR → KRW)
+        DEFAULT_EXCHANGE_RATES.put("V", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("XOM", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("KO", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("WMT", 1.32);
+        DEFAULT_EXCHANGE_RATES.put("LIN", 1.44);  // 독일 (EUR → KRW)
+        DEFAULT_EXCHANGE_RATES.put("MS", 1.32);
     }
 
-    public Double getExchangeRate(String[] tickers) {
+    public void  getExchangeRate(String[] tickers) {
         try {
             String URL = "https://m.search.naver.com/p/csearch/content/qapirender.nhn"
                     + "?key=calculator&pkid=141&q=환율&where=m&u1=keb"
                     + "&u6=standardUnit&u7=0&u3=USD&u4=KRW&u8=down&u2=1";
             ResponseEntity<String> response = restTemplate.getForEntity(URL, String.class);
+
             if (response.getStatusCode().is2xxSuccessful()) {
                 JsonNode jsonNode = objectMapper.readTree(response.getBody());
                 String exchangeRateStr = jsonNode.get("country").get(1).get("value").asText();
                 Double exchangeRate = Double.parseDouble(exchangeRateStr.replace(",", ""));
 
-                for (String ticker: tickers){
-                    String redisKey = "stock:" + ticker + ":exchange_rate";
-                    redisTemplate.opsForValue().set(redisKey, exchangeRate.toString());
+                // 1000원 대비 배율 변환 (환율 / 1000)
+                Double exchangeRateRatio = exchangeRate / 1000.0;
+
+                for (String ticker : tickers) {
+                    saveToRedis(ticker, exchangeRateRatio);
                 }
 
-                return exchangeRate;
             }
-        } catch (Exception e) {
+            else {
+                System.out.println("환율 API 응답 실패, 기본 환율을 사용합니다.");
+                setDefaultExchangeRates(tickers);
+            }
+        }  catch (Exception e) {
             System.out.println("환율 정보를 가져오는 데 실패했습니다: " + e.getMessage());
+            setDefaultExchangeRates(tickers);
         }
-        return null;
+    }
+
+    private void saveToRedis(String ticker, Double exchangeRate) {
+        String redisKey = "stock:" + ticker + ":exchange_rate";
+        redisTemplate.opsForValue().set(redisKey, exchangeRate.toString(), 5, TimeUnit.MINUTES);
+        System.out.println(ticker + ": 환율 " + exchangeRate + " (KRW) 저장 완료.");
+    }
+
+    private void setDefaultExchangeRates(String[] tickers) {
+        for (String ticker : tickers) {
+            Double defaultRate = DEFAULT_EXCHANGE_RATES.getOrDefault(ticker, 1.32); // 기본값: USD-KRW
+            saveToRedis(ticker, defaultRate);
+        }
     }
 }

--- a/data-service/src/main/java/finpago/dataservice/exchangeRate/controller/ExchangeRateController.java
+++ b/data-service/src/main/java/finpago/dataservice/exchangeRate/controller/ExchangeRateController.java
@@ -1,0 +1,37 @@
+package finpago.dataservice.exchangeRate.controller;
+
+import finpago.common.global.common.ApiResponse;
+import finpago.dataservice.exchangeRate.ExchangeRateService;
+import finpago.dataservice.exchangeRate.dto.ExchangeRateDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.concurrent.TimeUnit;
+
+@RestController
+@RequestMapping("/api/exchange-rate")
+@RequiredArgsConstructor
+public class ExchangeRateController {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    /**
+     * 특정 종목의 환율 조회 API
+     */
+    @GetMapping("/{ticker}")
+    public ResponseEntity<ApiResponse<ExchangeRateDto>> getExchangeRateByTicker(@PathVariable String ticker) {
+        String redisKey = "stock:" + ticker + ":exchange_rate";
+        String exchangeRate = redisTemplate.opsForValue().get(redisKey);
+
+        if (exchangeRate != null) {
+            ExchangeRateDto exchangeRateDto = new ExchangeRateDto(ticker, Double.parseDouble(exchangeRate));
+            return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "환율 조회 성공", exchangeRateDto));
+        } else {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.fail(HttpStatus.NOT_FOUND, "해당 종목의 환율 데이터가 없습니다."));
+        }
+    }
+}

--- a/data-service/src/main/java/finpago/dataservice/exchangeRate/dto/ExchangeRateDto.java
+++ b/data-service/src/main/java/finpago/dataservice/exchangeRate/dto/ExchangeRateDto.java
@@ -1,0 +1,13 @@
+package finpago.dataservice.exchangeRate.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ExchangeRateDto {
+    private String ticker;
+    private Double exchangeRate;
+}


### PR DESCRIPTION
## PR Type
- 기능추가

## 해당 PR에 대한 설명
우리 서비스에서 다루는 아래의 30개의 종목티커에 대한 실시간 환율 정보를 제공합니다
AAPL (애플)
MSFT (마이크로소프트)
NVDA (엔비디아)
GOOGL (알파벳)
AMZN (아마존)
META (메타)
TSLA (테슬라)
LLY (일라이 릴리)
AVGO (브로드컴)
JPM (JP모건)
IBM (IBM)
MA (마스터카드)
ORCL (오라클)
COST (코스트코)
UNH (유나이티드헬스)
NFLX (넷플릭스)
AMD (AMD)
TSM (TSMC)
ADBE (어도비)
CRM (세일즈포스)
NOW (서비스나우)
INTC (인텔)
PLTR (팔란티어)
ASML (ASML)
V (비자)
XOM (엑슨모빌)
KO (코카콜라)
WMT (월마트)
LIN (린데)
MS (모건스탠리)

1초 단위로 업데이트 -> 조회 실패시 default 값 적용 

## 스크린샷
![image](https://github.com/user-attachments/assets/b2a2a984-c2e3-4fe1-894b-cfee266064b9)

