### PR TITLE
P3-61(#56) [FEAT]: 예수금 및 보유주식 처리시 낙관적 락 적용

### DIFF
--- a/execution-service/src/main/java/finpago/executionservice/execution/config/UUIDToStringConverter.java
+++ b/execution-service/src/main/java/finpago/executionservice/execution/config/UUIDToStringConverter.java
@@ -1,0 +1,19 @@
+package finpago.executionservice.execution.config;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.UUID;
+
+@Converter(autoApply = true)
+public class UUIDToStringConverter implements AttributeConverter<UUID, String> {
+
+    @Override
+    public String convertToDatabaseColumn(UUID uuid) {
+        return uuid != null ? uuid.toString() : null;
+    }
+
+    @Override
+    public UUID convertToEntityAttribute(String uuidString) {
+        return uuidString != null ? UUID.fromString(uuidString) : null;
+    }
+}

--- a/execution-service/src/main/java/finpago/executionservice/execution/entity/BuyTrade.java
+++ b/execution-service/src/main/java/finpago/executionservice/execution/entity/BuyTrade.java
@@ -2,6 +2,7 @@ package finpago.executionservice.execution.entity;
 
 import finpago.common.global.common.BaseEntity;
 import finpago.common.global.enums.TradeStatus;
+import finpago.executionservice.execution.config.UUIDToStringConverter;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
@@ -17,8 +18,8 @@ import java.util.UUID;
 public class BuyTrade extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "buy_trade_number", length = 64, nullable = false, updatable = false)
+    @Convert(converter = UUIDToStringConverter.class)
     private UUID buyTradeNumber; // 매수 체결 고유 번호
 
     @Column(name = "buy_offer_number", length = 64, nullable = false)

--- a/execution-service/src/main/java/finpago/executionservice/execution/entity/SellTrade.java
+++ b/execution-service/src/main/java/finpago/executionservice/execution/entity/SellTrade.java
@@ -2,6 +2,7 @@ package finpago.executionservice.execution.entity;
 
 import finpago.common.global.common.BaseEntity;
 import finpago.common.global.enums.TradeStatus;
+import finpago.executionservice.execution.config.UUIDToStringConverter;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
@@ -17,8 +18,9 @@ import java.util.UUID;
 public class SellTrade extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
+//    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "sell_trade_number", length = 64, nullable = false, updatable = false)
+    @Convert(converter = UUIDToStringConverter.class)
     private UUID sellTradeNumber; // 매도 체결 고유 번호
 
     @Column(name = "sell_offer_number", length = 64, nullable = false)

--- a/execution-service/src/main/java/finpago/executionservice/execution/service/ExecutionService.java
+++ b/execution-service/src/main/java/finpago/executionservice/execution/service/ExecutionService.java
@@ -48,6 +48,7 @@ public class ExecutionService {
         TradeStatus status = (event.getUnfilledQuantity() > 0) ? TradeStatus.PENDING : TradeStatus.SUCCESS;
 
         BuyTrade trade = BuyTrade.builder()
+                .buyTradeNumber(event.getTradeId())
                 .buyOfferNumber(event.getBuyOfferNumber())
                 .tradeTicker(event.getStockTicker())
                 .buyerUserId(event.getBuyerUserId())
@@ -74,6 +75,7 @@ public class ExecutionService {
         TradeStatus status = (event.getUnfilledQuantity() > 0) ? TradeStatus.PENDING : TradeStatus.SUCCESS;
 
         SellTrade trade = SellTrade.builder()
+                .sellTradeNumber(event.getTradeId())
                 .sellOfferNumber(event.getSellOfferNumber())
                 .tradeTicker(event.getStockTicker())
                 .sellerUserId(event.getSellerUserId())

--- a/matching-service/src/main/java/finpago/matchingservice/matching/service/MatchingService.java
+++ b/matching-service/src/main/java/finpago/matchingservice/matching/service/MatchingService.java
@@ -35,7 +35,7 @@ public class MatchingService {
             Comparator.comparing(OrderCreateReqEvent::getCreatedAt)
     );
 
-    private static final long MAX_WAIT_TIME = 5 * 60 * 1000; // 5분 (밀리초 단위)
+    private static final long MAX_WAIT_TIME = 5 * 1000; // 5초 (밀리초 단위)
 
     public void processOrder(OrderCreateReqEvent order) {
         log.info("주문 접수: {}", order);

--- a/order-service/src/main/java/finpago/orderservice/order/messaging/consumer/OrderConsumer.java
+++ b/order-service/src/main/java/finpago/orderservice/order/messaging/consumer/OrderConsumer.java
@@ -13,7 +13,8 @@ public class OrderConsumer {
 
     private final OrderService orderService;
 
-    @KafkaListener(topics = "unmatched-orders-topic", groupId = "order-service-group")
+    @KafkaListener(topics = "unmatched-orders-topic", groupId = "order-service-group",
+            containerFactory = "kafkaRetryListenerContainerFactory")
     public void handleUnmatchedOrder(OrderCreateReqEvent event) {
         log.warn("미체결 주문 수신 - 다시 매칭 모듈로 전송 준비: {}", event);
         orderService.retryUnmatchedOrder(event);

--- a/settlement-service/build.gradle
+++ b/settlement-service/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.kafka:spring-kafka'
-    implementation 'org.redisson:redisson-spring-boot-starter:3.17.7'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.22.1'
 
     //common
     implementation project(':common')

--- a/settlement-service/src/main/java/finpago/settlementservice/settlement/config/redis/RedisConfig.java
+++ b/settlement-service/src/main/java/finpago/settlementservice/settlement/config/redis/RedisConfig.java
@@ -3,6 +3,7 @@ package finpago.settlementservice.settlement.config.redis;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
+import org.redisson.codec.JsonJacksonCodec;
 import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -25,6 +26,7 @@ public class RedisConfig {
     public RedissonClient redissonClient() {
         Config config = new Config();
         config.useSingleServer().setAddress("redis://" + host + ":" + port);
+        config.setCodec(new JsonJacksonCodec());
         return Redisson.create(config);
     }
 

--- a/settlement-service/src/main/java/finpago/settlementservice/settlement/service/SettlementService.java
+++ b/settlement-service/src/main/java/finpago/settlementservice/settlement/service/SettlementService.java
@@ -8,6 +8,8 @@ import finpago.common.global.messaging.TradeMatchingEvent;
 import finpago.settlementservice.settlement.messaging.producer.SettlementProducer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +22,7 @@ public class SettlementService {
 
     private final StringRedisTemplate redisTemplate;
     private final SettlementProducer settlementProducer;
+    private final RedissonClient redissonClient; // Redisson 클라이언트 주입
 
     private static final long DEFAULT_BALANCE = 10000000; // 기본 예수금
     private static final long DEFAULT_STOCKS = 100; // 기본 보유 주식 수량
@@ -30,14 +33,15 @@ public class SettlementService {
     @Transactional
     public void processBuySettlement(BuyTradeMatchEvent event) {
         validateBuyerBalance(event);
-
+        System.out.println("검증완료");
         Float exchangeRate = getExchangeRate(event.getStockTicker());
         event.setExchangeRate(exchangeRate);
 
+        System.out.println("exchangeRate: " + exchangeRate);
         updateBatchBalance(event.getBuyerUserId(), -event.getTradePrice() * event.getTradeQuantity());
         updateBalance(event.getBuyerUserId(), -event.getTradePrice() * event.getTradeQuantity());
         updateHoldings(event.getBuyerUserId(), event.getStockTicker(), event.getTradeQuantity());
-        updateStockForFxTracking(event.getBuyerUserId(), event.getStockTicker(), event.getTradeQuantity(), exchangeRate, event.getTradePrice());
+//        updateStockForFxTracking(event.getBuyerUserId(), event.getStockTicker(), event.getTradeQuantity(), exchangeRate, event.getTradePrice());
 
         settlementProducer.sendBuySettlementSuccess(event);
         log.info("매수 정산 완료: {}", event);
@@ -53,7 +57,7 @@ public class SettlementService {
 
         updateBatchBalance(event.getSellerUserId(), event.getTradePrice() * event.getTradeQuantity());
         updateHoldings(event.getSellerUserId(), event.getStockTicker(), -event.getTradeQuantity());
-        updateStockForFxTracking(event.getSellerUserId(), event.getStockTicker(), -event.getTradeQuantity(), exchangeRate, event.getTradePrice());
+//        updateStockForFxTracking(event.getSellerUserId(), event.getStockTicker(), -event.getTradeQuantity(), exchangeRate, event.getTradePrice());
 
         settlementProducer.sendSellSettlementSuccess(event);
         log.info("매도 정산 완료: {}", event);
@@ -63,6 +67,7 @@ public class SettlementService {
      * 매수자의 예수금 검증
      */
     private void validateBuyerBalance(BuyTradeMatchEvent event) {
+        System.out.println("들어와요");
         Long buyerAvailableBalance = getCachedAvailableBalance(event.getBuyerUserId());
         Long requiredAmount = event.getTradePrice() * event.getTradeQuantity();
 
@@ -132,13 +137,27 @@ public class SettlementService {
     }
 
     /**
-     * 실제 예수금 업데이트
+     * 예수금 업데이트 (Redisson 낙관적 락 적용)
      */
     private void updateBalance(Long userId, Long amount) {
         String balanceKey = "user:" + userId + ":balance";
-        Long currentBalance = getCachedAvailableBalance(userId);
-        redisTemplate.opsForValue().set(balanceKey, String.valueOf(currentBalance + amount), EXPIRATION_DAYS, TimeUnit.DAYS);
+        RBucket<String> balanceBucket = redissonClient.getBucket(balanceKey);
+
+        boolean updated = false;
+        while (!updated) {
+            String balanceStr = balanceBucket.get();
+            Long currentBalance = (balanceStr != null) ? Long.parseLong(balanceStr) : DEFAULT_BALANCE;
+            Long newBalance = currentBalance + amount;
+
+            updated = balanceBucket.trySet(String.valueOf(newBalance), EXPIRATION_DAYS, TimeUnit.DAYS);
+
+            if (!updated) {
+                log.warn("예수금 업데이트 충돌 발생 - 재시도 중... (User ID: {}, 현재 예수금: {})", userId, currentBalance);
+            }
+        }
+        log.info("예수금 업데이트 완료 - User ID: {}, 변경 후 예수금: {}", userId, balanceBucket.get());
     }
+
 
     /**
      * 배치 계산용 예수금 업데이트 (D+2일 반영용)
@@ -147,37 +166,73 @@ public class SettlementService {
      */
     private void updateBatchBalance(Long userId, Long amount) {
         String batchBalanceKey = "user:" + userId + ":batch_balance";
-        Long currentBalance = getCachedAvailableBalance(userId);
-        redisTemplate.opsForValue().set(batchBalanceKey, String.valueOf(currentBalance + amount), EXPIRATION_DAYS, TimeUnit.DAYS);
+        RBucket<String> batchBalanceBucket = redissonClient.getBucket(batchBalanceKey);
+
+        boolean exists = batchBalanceBucket.isExists();
+        log.info("batchBalanceKey 존재 여부: {}", exists);
+
+        boolean updated = false;
+        while (!updated) {
+            String balanceStr = batchBalanceBucket.get();
+            Long currentBalance = (balanceStr != null) ? Long.parseLong(balanceStr) : DEFAULT_BALANCE;
+
+            Long newBalance = currentBalance + amount;
+            log.info("User ID: {}, 기존 배치 예수금: {}, 추가 금액: {}, 변경 후 배치 예수금: {}",
+                    userId, currentBalance, amount, newBalance);
+
+            // 기존 값과 동일한 경우에만 업데이트 (낙관적 락 적용)
+            updated = batchBalanceBucket.trySet(String.valueOf(newBalance), EXPIRATION_DAYS, TimeUnit.DAYS);
+
+            if (!updated) {
+                log.warn("배치 예수금 업데이트 충돌 발생 - 재시도 중... (User ID: {}, 현재 배치 예수금: {})", userId, currentBalance);
+            }
+        }
+        log.info("배치 예수금 업데이트 완료 - User ID: {}, 변경 후 예수금: {}", userId, batchBalanceBucket.get());
     }
 
     /**
-     * 보유 주식 업데이트 (배치)
+     * 보유 주식 업데이트 (Redisson 낙관적 락 적용)
      */
     private void updateHoldings(Long userId, String stockTicker, Long quantity) {
         String stockKey = "user:" + userId + ":holdings:" + stockTicker;
-        Long currentStocks = getCachedAvailableStocks(userId, stockTicker);
-        redisTemplate.opsForValue().set(stockKey, String.valueOf(currentStocks + quantity), EXPIRATION_DAYS, TimeUnit.DAYS);
+        RBucket<String> stockBucket = redissonClient.getBucket(stockKey);
+
+        boolean updated = false;
+        while (!updated) {
+            String stockStr = stockBucket.get();
+            Long currentStocks = (stockStr != null) ? Long.parseLong(stockStr) : DEFAULT_STOCKS;
+            Long newStocks = currentStocks + quantity;
+
+            updated = stockBucket.trySet(String.valueOf(newStocks), EXPIRATION_DAYS, TimeUnit.DAYS);
+
+            if (!updated) {
+                log.warn("보유 주식 업데이트 충돌 발생 - 재시도 중... (User ID: {}, 주식: {}, 현재 보유량: {})",
+                        userId, stockTicker, currentStocks);
+            }
+        }
+        log.info("보유 주식 업데이트 완료 - User ID: {}, 주식: {}, 변경 후 수량: {}", userId, stockTicker, stockBucket.get());
     }
-
-
-    /**
-     * 환차손익 계산을 위해 체결 당시 환율, 수량 및 거래 가격을 Redis에 저장
-     */
-    private void updateStockForFxTracking(Long userId, String stockTicker, Long quantity, Float exchangeRate, Long tradePrice) {
-        String holdingsFxKey = "user:" + userId + ":holdings-fx:" + stockTicker;
-
-        // 저장할 데이터 형식: "환율:거래수량:거래가격"
-        String tradeInfo = exchangeRate + ":" + quantity + ":" + tradePrice;
-
-        // Redis List에 저장 (FIFO 구조로 저장)
-        redisTemplate.opsForList().rightPush(holdingsFxKey, tradeInfo);
-
-        // 데이터 유효기간 설정 (30일 후 자동 삭제)
-        redisTemplate.expire(holdingsFxKey, 30, TimeUnit.DAYS);
-
-        log.info("[환차손익 데이터 저장] 사용자ID: {}, 주식: {}, 체결 환율: {}, 체결 수량: {}, 체결 가격: {}",
-                userId, stockTicker, exchangeRate, quantity, tradePrice);
-    }
-
 }
+
+
+//
+//    /**
+//     * 환차손익 계산을 위해 체결 당시 환율, 수량 및 거래 가격을 Redis에 저장
+//     */
+//    private void updateStockForFxTracking(Long userId, String stockTicker, Long quantity, Float exchangeRate, Long tradePrice) {
+//        String holdingsFxKey = "user:" + userId + ":holdings-fx:" + stockTicker;
+//
+//        // 저장할 데이터 형식: "환율:거래수량:거래가격"
+//        String tradeInfo = exchangeRate + ":" + quantity + ":" + tradePrice;
+//
+//        // Redis List에 저장 (FIFO 구조로 저장)
+//        redisTemplate.opsForList().rightPush(holdingsFxKey, tradeInfo);
+//
+//        // 데이터 유효기간 설정 (30일 후 자동 삭제)
+//        redisTemplate.expire(holdingsFxKey, 30, TimeUnit.DAYS);
+//
+//        log.info("[환차손익 데이터 저장] 사용자ID: {}, 주식: {}, 체결 환율: {}, 체결 수량: {}, 체결 가격: {}",
+//                userId, stockTicker, exchangeRate, quantity, tradePrice);
+//    }
+
+


### PR DESCRIPTION
## PR Type
- 기능 개선


## 해당 PR에 대한 설명
### 여러 트랜잭션이 동일한 키를 수정하는 경우, 충돌이 발생하면 다시 시도
- 기존 Redis에 String으로 저장된 값을 가져올 때 Long.parseLong()을 사용하여 변환 후 연산하도록 수정
- Redisson 기반 낙관적 락 (trySet()) 적용하여 동시성 문제 해결
- updateBatchBalance(), updateBalanceWithLock(), updateHoldingsWithLock() 메서드에 동시 업데이트 충돌 방지 로직 추가