### PR TITLE
P3-120(#136) [FEAT]: 현재가 보다 높은 높거나 낮은 가격으로 매수,매도시 현재가로 체결되도록 로직 변경

### DIFF
--- a/data-service/src/main/java/finpago/dataservice/exchangeRate/controller/ExchangeRateController.java
+++ b/data-service/src/main/java/finpago/dataservice/exchangeRate/controller/ExchangeRateController.java
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeUnit;
 @RestController
 @RequestMapping("/v1/api/exchange-rate")
 @RequiredArgsConstructor
+@CrossOrigin(origins = "*")
 public class ExchangeRateController {
 
     private final RedisTemplate<String, String> redisTemplate;
@@ -23,6 +24,7 @@ public class ExchangeRateController {
      */
     @GetMapping("/{ticker}")
     public ResponseEntity<ApiResponse<ExchangeRateDto>> getExchangeRateByTicker(@PathVariable String ticker) {
+        System.out.println("요청들어옵니다");
         String redisKey = "stock:" + ticker + ":exchange_rate";
         String exchangeRate = redisTemplate.opsForValue().get(redisKey);
 

--- a/data-service/src/main/resources/application-dev.yml
+++ b/data-service/src/main/resources/application-dev.yml
@@ -24,6 +24,7 @@ spring:
 
 server:
   port: 19099
+  address: 0.0.0.0
 
 eureka:
   client:

--- a/execution-service/src/main/java/finpago/executionservice/execution/config/auth/SecurityConfig.java
+++ b/execution-service/src/main/java/finpago/executionservice/execution/config/auth/SecurityConfig.java
@@ -12,6 +12,10 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -23,7 +27,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .cors(cors -> cors.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // ✅ 세션 사용 X
                 .authorizeHttpRequests(auth -> auth
@@ -32,6 +36,19 @@ public class SecurityConfig {
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class); // JWT 필터 추가
 
         return http.build();
+    }
+
+    @Bean
+    public UrlBasedCorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("*")); // 모든 Origin 허용
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(false); // 인증 정보 포함 사용 안 함
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 
     @Bean

--- a/execution-service/src/main/resources/application-dev.yml
+++ b/execution-service/src/main/resources/application-dev.yml
@@ -38,6 +38,7 @@ common:
 
 server:
   port: 19095
+  address: 0.0.0.0
 
 eureka:
   client:

--- a/filling-service/src/main/java/finpago/fillingservice/controller/FillingController.java
+++ b/filling-service/src/main/java/finpago/fillingservice/controller/FillingController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/api/fillings")
+@CrossOrigin(origins = "*")
 public class FillingController {
 
     private final FillingService fillingService;

--- a/filling-service/src/main/resources/application-dev.yml
+++ b/filling-service/src/main/resources/application-dev.yml
@@ -33,6 +33,7 @@ common:
 
 server:
   port: 19098
+  address: 0.0.0.0
 
 eureka:
   client:

--- a/gateway/src/main/resources/application-dev.yml
+++ b/gateway/src/main/resources/application-dev.yml
@@ -1,5 +1,6 @@
 server:
   port: 19091
+  address: 0.0.0.0
 
 eureka:
   client:

--- a/matching-service/src/main/java/finpago/matchingservice/matching/service/MatchingService.java
+++ b/matching-service/src/main/java/finpago/matchingservice/matching/service/MatchingService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +27,8 @@ public class MatchingService {
 
     private final MatchingProducer matchingProducer;
     private final StringRedisTemplate redisTemplate;
+    private static final long DEFAULT_BALANCE = 10000000;
+    private static final long EXPIRATION_DAYS = 30; // Redis 데이터 보관 기간 (30일)
 
     //주문 시간순 정렬
     private final PriorityQueue<OrderCreateReqEvent> orders = new PriorityQueue<>(
@@ -108,14 +111,20 @@ public class MatchingService {
                 long maxTradePrice = (long) sortedTrades.get(sortedTrades.size() - 1).get("current_price");
                 long minTradePrice = (long) sortedTrades.get(0).get("current_price");
 
+
                 System.out.println("maxTradePrice: " + maxTradePrice);
                 System.out.println("minTradePrice: " + minTradePrice);
 
                 if (order.getOfferType() == OrderType.BUY) {
+
+                    long currentPrice = maxTradePrice;
                     System.out.println("들어와요33");
                     if (order.getOfferPrice() > maxTradePrice) {
                         System.out.println("들어와요44");
-                        handleTradeExecution(order, order.getOfferQuantity(), 0L, order.getOfferPrice(), true);
+                        handleTradeExecution(order, order.getOfferQuantity(), 0L, currentPrice, true);
+                        long refundAmount = (order.getOfferPrice() - currentPrice) * order.getOfferQuantity();
+                        updateAvailableBalance(order.getUserId(), refundAmount);
+
                     } else {
                         System.out.println("들어와요55");
                         int matchedIndex = linearSearch(sortedTrades, order.getOfferPrice());
@@ -165,8 +174,12 @@ public class MatchingService {
                         }
                     }
                 } else {
+                    long currentPrice = minTradePrice;
                     if (order.getOfferPrice() < minTradePrice) {
-                        handleTradeExecution(order, order.getOfferQuantity(), 0L, order.getOfferPrice(), false);
+
+                        handleTradeExecution(order, order.getOfferQuantity(), 0L, currentPrice, false);
+                        long refundAmount = (currentPrice - order.getOfferPrice()) * order.getOfferQuantity();
+                        updateAvailableBalance(order.getUserId(), refundAmount);
                     } else {
                         int matchedIndex = linearSearch(sortedTrades, order.getOfferPrice());
                         if (matchedIndex != -1) {
@@ -323,5 +336,22 @@ public class MatchingService {
             log.error("Redis 환율 데이터 변환 오류: {}", e.getMessage());
             return 1.0f;
         }
+    }
+
+    /**
+     * 사용 가능 예수금 업데이트 (30일 보관)
+     */
+    private void updateAvailableBalance(Long userId, Long amount) {
+        System.out.println("유저아이딩: " + userId);
+        System.out.println("돈은용: " + amount);
+
+        String key = "user:" + userId + ":available_balance";
+        Long current = getCachedAvailableBalance(userId);
+        redisTemplate.opsForValue().set(key, String.valueOf(current + amount), EXPIRATION_DAYS, TimeUnit.DAYS);
+    }
+
+    private Long getCachedAvailableBalance(Long userId) {
+        String key = "user:" + userId + ":available_balance";
+        return redisTemplate.opsForValue().get(key) != null ? Long.parseLong(redisTemplate.opsForValue().get(key)) : DEFAULT_BALANCE;
     }
 }

--- a/matching-service/src/main/java/finpago/matchingservice/matching/service/RedisTradeScheduler.java
+++ b/matching-service/src/main/java/finpago/matchingservice/matching/service/RedisTradeScheduler.java
@@ -1,64 +1,64 @@
-package finpago.matchingservice.matching.service;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
-
-@Slf4j
-@Component
-@RequiredArgsConstructor
-public class RedisTradeScheduler {
-
-    private final StringRedisTemplate redisTemplate;
-    private final ObjectMapper objectMapper = new ObjectMapper();
-    private final Random random = new Random();
-
-    private static final String[] STOCK_TICKERS = {"TSLA", "GOOGLE", "AAPL", "AMZN", "MSFT"};
-
-    /**
-     * 1초마다 Redis 체결 데이터 갱신
-     */
-    @Scheduled(fixedRate = 2000)  // 1초마다 실행
-    public void updateDummyData() {
-        for (String stock : STOCK_TICKERS) {
-            String redisKey = "stock:" + stock + ":purchase";
-
-            // 최신 데이터 삽입
-            Map<String, Object> tradeData = new HashMap<>();
-            tradeData.put("current_price", generateRandomPrice(stock));
-            tradeData.put("volume", random.nextInt(100) + 1); // 1 ~ 100 랜덤 수량
-            tradeData.put("timestamp", System.currentTimeMillis());
-
-            try {
-                String tradeJson = objectMapper.writeValueAsString(tradeData);
-                redisTemplate.opsForList().leftPush(redisKey, tradeJson); // 최신 데이터가 앞에 오도록 저장
-                redisTemplate.opsForList().trim(redisKey, 0, 19); // 최신 20개만 유지
-            } catch (JsonProcessingException e) {
-                log.error("Redis 체결 데이터 갱신 오류: {}", e.getMessage());
-            }
-        }
-        log.info("🔄 Redis 체결 데이터 갱신 완료");
-    }
-
-    /**
-     * 랜덤 가격 생성
-     */
-    private double generateRandomPrice(String stock) {
-        return switch (stock) {
-            case "TSLA" -> 600 + random.nextDouble() * 50;  // 600~650
-            case "GOOGLE" -> 2500 + random.nextDouble() * 100; // 2500~2600
-            case "AAPL" -> 140 + random.nextDouble() * 10; // 140~150
-            case "AMZN" -> 3200 + random.nextDouble() * 200; // 3200~3400
-            case "MSFT" -> 280 + random.nextDouble() * 20; // 280~300
-            default -> 100 + random.nextDouble() * 50; // 기본값
-        };
-    }
-}
+//package finpago.matchingservice.matching.service;
+//
+//import com.fasterxml.jackson.core.JsonProcessingException;
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.data.redis.core.StringRedisTemplate;
+//import org.springframework.scheduling.annotation.Scheduled;
+//import org.springframework.stereotype.Component;
+//
+//import java.util.HashMap;
+//import java.util.Map;
+//import java.util.Random;
+//
+//@Slf4j
+//@Component
+//@RequiredArgsConstructor
+//public class RedisTradeScheduler {
+//
+//    private final StringRedisTemplate redisTemplate;
+//    private final ObjectMapper objectMapper = new ObjectMapper();
+//    private final Random random = new Random();
+//
+//    private static final String[] STOCK_TICKERS = {"TSLA", "GOOGLE", "AAPL", "AMZN", "MSFT"};
+//
+//    /**
+//     * 1초마다 Redis 체결 데이터 갱신
+//     */
+//    @Scheduled(fixedRate = 2000)  // 1초마다 실행
+//    public void updateDummyData() {
+//        for (String stock : STOCK_TICKERS) {
+//            String redisKey = "stock:" + stock + ":purchase";
+//
+//            // 최신 데이터 삽입
+//            Map<String, Object> tradeData = new HashMap<>();
+//            tradeData.put("current_price", generateRandomPrice(stock));
+//            tradeData.put("volume", random.nextInt(100) + 1); // 1 ~ 100 랜덤 수량
+//            tradeData.put("timestamp", System.currentTimeMillis());
+//
+//            try {
+//                String tradeJson = objectMapper.writeValueAsString(tradeData);
+//                redisTemplate.opsForList().leftPush(redisKey, tradeJson); // 최신 데이터가 앞에 오도록 저장
+//                redisTemplate.opsForList().trim(redisKey, 0, 19); // 최신 20개만 유지
+//            } catch (JsonProcessingException e) {
+//                log.error("Redis 체결 데이터 갱신 오류: {}", e.getMessage());
+//            }
+//        }
+//        log.info("🔄 Redis 체결 데이터 갱신 완료");
+//    }
+//
+//    /**
+//     * 랜덤 가격 생성
+//     */
+//    private double generateRandomPrice(String stock) {
+//        return switch (stock) {
+//            case "TSLA" -> 600 + random.nextDouble() * 50;  // 600~650
+//            case "GOOGLE" -> 2500 + random.nextDouble() * 100; // 2500~2600
+//            case "AAPL" -> 140 + random.nextDouble() * 10; // 140~150
+//            case "AMZN" -> 3200 + random.nextDouble() * 200; // 3200~3400
+//            case "MSFT" -> 280 + random.nextDouble() * 20; // 280~300
+//            default -> 100 + random.nextDouble() * 50; // 기본값
+//        };
+//    }
+//}

--- a/matching-service/src/main/resources/application-dev.yml
+++ b/matching-service/src/main/resources/application-dev.yml
@@ -20,6 +20,7 @@ common:
 
 server:
   port: 19094
+  address: 0.0.0.0
 
 eureka:
   client:

--- a/notification-service/src/main/resources/application-dev.yml
+++ b/notification-service/src/main/resources/application-dev.yml
@@ -12,6 +12,8 @@ spring:
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 server:
   port: 19097
+  address: 0.0.0.0
+
 eureka:
   client:
     service-url:

--- a/order-service/src/main/java/finpago/orderservice/order/config/auth/SecurityConfig.java
+++ b/order-service/src/main/java/finpago/orderservice/order/config/auth/SecurityConfig.java
@@ -13,6 +13,10 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -24,7 +28,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .cors(cors -> cors.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // ✅ 세션 사용 X
                 .authorizeHttpRequests(auth -> auth
@@ -33,6 +37,19 @@ public class SecurityConfig {
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class); // JWT 필터 추가
 
         return http.build();
+    }
+
+    @Bean
+    public UrlBasedCorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("*")); // 모든 Origin 허용
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(false); // 인증 정보 포함 사용 안 함
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 
     @Bean

--- a/order-service/src/main/resources/application-dev.yml
+++ b/order-service/src/main/resources/application-dev.yml
@@ -40,6 +40,7 @@ common:
 
 server:
   port: 19093
+  address: 0.0.0.0
 
 eureka:
   client:

--- a/service-discovery/src/main/resources/application-dev.yml
+++ b/service-discovery/src/main/resources/application-dev.yml
@@ -4,6 +4,7 @@ spring:
 
 server:
   port: 19090
+  address: 0.0.0.0
 
 eureka:
   client:

--- a/settlement-service/src/main/resources/application-dev.yml
+++ b/settlement-service/src/main/resources/application-dev.yml
@@ -21,6 +21,7 @@ common:
 
 server:
   port: 19096
+  address: 0.0.0.0
 
 eureka:
   client:

--- a/user-service/src/main/java/finpago/userservice/account/controller/BalanceController.java
+++ b/user-service/src/main/java/finpago/userservice/account/controller/BalanceController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/v1/api/balance")
 @RequiredArgsConstructor
+@CrossOrigin(origins = "*")
 public class BalanceController {
 
     private final BalanceService balanceService;

--- a/user-service/src/main/java/finpago/userservice/user/config/SecurityConfig.java
+++ b/user-service/src/main/java/finpago/userservice/user/config/SecurityConfig.java
@@ -17,6 +17,10 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -33,7 +37,7 @@ public class SecurityConfig {
         System.out.println(" Security Filter Chain 설정 시작...");
 
         http
-                .cors(cors -> cors.disable()) // CORS 비활성화
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))// CORS 비활성화
                 .csrf(csrf -> csrf.disable())  // CSRF 완전 비활성화
                 .headers(headers -> headers.frameOptions(frame -> frame.disable()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -47,7 +51,18 @@ public class SecurityConfig {
         return http.build();
     }
 
+    @Bean
+    public UrlBasedCorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("*")); // 모든 Origin 허용
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(false); // 인증 정보 포함 사용 안 함
 
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {

--- a/user-service/src/main/resources/application-dev.yml
+++ b/user-service/src/main/resources/application-dev.yml
@@ -40,6 +40,7 @@ common:
 
 server:
   port: 19092
+  address: 0.0.0.0
 
 eureka:
   instance:


### PR DESCRIPTION
## PR Type
- 로직 수정

## 해당 PR에 대한 설명

### 변경 사항
- 주문 체결 시 `order.getOfferPrice()` 대신 Redis에서 조회한 `current_price` 사용
- 매수 주문이 `current_price`보다 높으면 차액을 `available_balance`에 반환
- 매도 주문이 `current_price`보다 낮으면 차액을 `available_balance`에 추가
- 체결된 주문의 가격 조정 로직 반영

### 개선 효과
- 보다 정확한 가격 기반 주문 체결 가능
- 체결 후 남은 차액을 자동 조정하여 예수금 관리 최적화

## 스크린샷
![image](https://github.com/user-attachments/assets/1d93abfb-016f-42d7-8a1f-68562fb4a17f)
